### PR TITLE
Add Slack hook for Travis and fix CodeDeploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 dist: trusty
 sudo: required
 services:
-  - postgresql
+- postgresql
 addons:
   postgresql: 9.6
   apt:
@@ -24,8 +24,8 @@ script:
 - python manage.py migrate
 - pytest
 notifications:
-  webhooks:
-  - https://semabot.datamade.us/travis/
+  slack:
+    secure: WZE+shuIOGZGq+jBiM8AnsQH9uDmJ5utr3haTUh4bJuZyaE7ObzK3s4BJw5YUY9gaPu5X8pYGtD77Cz2Q+WwWeIOPnFGa7597n7aACONHE2kRr+gsDct+20tNnlYEgj1DykPYTtQ4SxgVR9aMl6+H9qr62nMWL2oOfPVhDe6ELMUdFkjsnCtKMUXUCc/Q60p4MhS9oh15gOZivrj/FDBxcqwdToXoDfXI5QkV6u620JhS/lFHGDk6vNllENsjuGh/pPNgXUY9WenaCWjS16lfeZhNP37mjTr790ET9ZtkS/dnx0A7O6t0fcgeUruV7jr25Z337RUtSBeUdWQRV2k7+z3vEWTIidJ+YacqtVUArCfBKr7mes5ADsMlLiEOcREBvQXdQ0osHiFo5vHXSjlEs++10TWvX/2SCiT6gW2x6LwdoX6lWw5KE3Yq8XySN/nxdD1wdRwjF3LDzKJmuZaa5O5VW0w7Ui7cXc89zQ/l5qAOH2Fh6wrYPqpbOS9dFsH/+z4ZtqFfbbPHaOMMGsOEmWI1pR/+K5w0MvzXTUcaYSit6F3C+aqlpWm2JHEWEJR6doH6mDYMxnnj/mqgVxh4+oCWFiECFgw+X3+ToGkSOAifudBZEA+GUKEfR1iCSRDbACFOsAOSbPzB49G4Tl/WtGk1VoQInZUTBSOna+TZro=
 deploy:
   provider: codedeploy
   access_key_id: AKIAJNYGDLOJKHOUWCAA

--- a/scripts/after_install.sh
+++ b/scripts/after_install.sh
@@ -16,7 +16,7 @@ sudo -H -u datamade $venv_dir/bin/pip install --upgrade pip
 sudo -H -u datamade $venv_dir/bin/pip install --upgrade setuptools
 sudo -H -u datamade $venv_dir/bin/pip install -r $project_dir/requirements.txt --upgrade
 
-cd $project_dir && sudo -H -u datamade GPG=gpg2 blackbox_postdeploy
+cd $project_dir && sudo -H -u datamade blackbox_postdeploy
 mv $project_dir/configs/local_settings.py.$DEPLOYMENT_GROUP_NAME $project_dir/committeeoversight/local_settings.py && chown datamade.www-data $project_dir/committeeoversight/local_settings.py
 
 psql -U postgres -tc "SELECT 1 FROM pg_database WHERE datname = 'hearings'" | grep -q 1 || psql -U postgres -c "CREATE DATABASE hearings"

--- a/scripts/after_install.sh
+++ b/scripts/after_install.sh
@@ -16,7 +16,7 @@ sudo -H -u datamade $venv_dir/bin/pip install --upgrade pip
 sudo -H -u datamade $venv_dir/bin/pip install --upgrade setuptools
 sudo -H -u datamade $venv_dir/bin/pip install -r $project_dir/requirements.txt --upgrade
 
-cd $project_dir && sudo -H -u datamade blackbox_postdeploy
+cd $project_dir && sudo -H -u datamade GPG=gpg2 blackbox_postdeploy
 mv $project_dir/configs/local_settings.py.$DEPLOYMENT_GROUP_NAME $project_dir/committeeoversight/local_settings.py && chown datamade.www-data $project_dir/committeeoversight/local_settings.py
 
 psql -U postgres -tc "SELECT 1 FROM pg_database WHERE datname = 'hearings'" | grep -q 1 || psql -U postgres -c "CREATE DATABASE hearings"

--- a/scripts/after_install.sh
+++ b/scripts/after_install.sh
@@ -16,7 +16,6 @@ sudo -H -u datamade $venv_dir/bin/pip install --upgrade pip
 sudo -H -u datamade $venv_dir/bin/pip install --upgrade setuptools
 sudo -H -u datamade $venv_dir/bin/pip install -r $project_dir/requirements.txt --upgrade
 
-cd $project_dir && sudo -H -u datamade GPG=gpg2 blackbox_postdeploy
 mv $project_dir/configs/local_settings.py.$DEPLOYMENT_GROUP_NAME $project_dir/committeeoversight/local_settings.py && chown datamade.www-data $project_dir/committeeoversight/local_settings.py
 
 psql -U postgres -tc "SELECT 1 FROM pg_database WHERE datname = 'hearings'" | grep -q 1 || psql -U postgres -c "CREATE DATABASE hearings"

--- a/scripts/before_install.sh
+++ b/scripts/before_install.sh
@@ -4,4 +4,6 @@ set -euo pipefail
 # Make directory for project
 mkdir -p /home/datamade/committee-oversight
 
-cd /opt/codedeploy-agent/deployment-root/$DEPLOYMENT_GROUP_ID/$DEPLOYMENT_ID/deployment-archive/ && chown -R datamade.datamade . && sudo -H -u datamade blackbox_postdeploy
+apt-get update
+apt-get install -y gnupg2
+cd /opt/codedeploy-agent/deployment-root/$DEPLOYMENT_GROUP_ID/$DEPLOYMENT_ID/deployment-archive/ && chown -R datamade.datamade . && sudo -H -u datamade GPG=gpg2 blackbox_postdeploy


### PR DESCRIPTION
## Overview

Closes #70. Integrates Travis for Slack in this repo. 

I also set up CodeDeploy notifications for #70 and realized that staging server deployments had been failing silently for a familiar problem: that pesky GPG update. 

First, I modified the `before_install` script to accommodate using the code from DataMade's [deployment template](https://github.com/datamade/deploy-a-site/blob/d1237974f554bb87cba27346edd89dea412bd5b4/templates/django/%7B%7Bcookiecutter.directory_name%7D%7D/scripts/before_install.sh). That made `before_install` pass but deployment failed on `after_install` with this message:

```
[stdout] Running setup.py install for sqlalchemy: started
[stdout] Running setup.py install for sqlalchemy: finished with status 'done'
[stdout] Running setup.py install for python-dateutil: started
[stdout] Running setup.py install for python-dateutil: finished with status 'done'
[stdout] Running setup.py install for csvkit: started
[stdout] Running setup.py install for csvkit: finished with status 'done'
[stdout] Running setup.py install for opencivicdata: started
[stdout] Running setup.py install for opencivicdata: finished with status 'done'
[stdout]Successfully installed MarkupSafe-1.1.1 atomicwrites-1.3.0 attrs-19.1.0 certifi-2019.6.16 chardet-3.0.4 csvkit-0.9.3 django-2.1.12 django-crispy-forms-1.7.2 django-datatables-view-1.17.0 et-xmlfile-1.0.1 gunicorn-19.9.0 idna-2.8 importlib-metadata-0.20 jdcal-1.4.1 jinja2-2.10.1 more-itertools-7.2.0 opencivicdata-2.3.0 openpyxl-2.5.14 packaging-19.1 pathlib2-2.3.4 pluggy-0.12.0 psycopg2-2.7.5 psycopg2-binary-2.8.3 py-1.8.0 pyparsing-2.4.2 pytest-5.1.2 pytest-django-3.5.1 python-dateutil-2.2 pytz-2019.2 requests-2.22.0 six-1.12.0 sqlalchemy-1.3.0 urllib3-1.24.2 wcwidth-0.1.7 xlrd-1.2.0 zipp-0.6.0
[stderr]========== Importing keychain: START
[stderr]gpg: [don't know]: invalid packet (ctb=00)
[stderr]gpg: WARNING: nothing exported
[stderr]gpg: key export failed: invalid packet
```

I looked in the script and it looked like it was failing on `blackbox_postdeploy`, so I set that to use gpg2 as well:

```
cd $project_dir && sudo -H -u datamade GPG=gpg2 blackbox_postdeploy
```

It worked! But then I wondered why I was running `blackbox_postdeploy` in `after_install` in the first place. After looking at the templated `after_install` script, I realized I don't need it there at all—I believe this app was originally deployed at a transition moment in DataMade devops. I went ahead and deleted that line entirely, manually deployed, and everything is working fine.

## Testing Instructions

 * Do this PR's builds result in a Slack notification? Then we're good! 

Update: it worked!