### PR TITLE
Add Wagtail userbar

### DIFF
--- a/committeeoversightapp/static/css/custom.css
+++ b/committeeoversightapp/static/css/custom.css
@@ -183,6 +183,13 @@ input[type='checkbox'] {
   border-radius: .25rem;
 }
 
+.wagtail-userbar-trigger.wagtail-icon-wagtail::before {
+  font-family: "Font Awesome 5 Free";
+  font-weight: 900;
+  content: "\f303";
+  font-size: 1.4rem !important;
+}
+
 /* Small devices (landscape phones, 576px and up) */
 @media (max-width: 767px) {
   .pagination {

--- a/committeeoversightapp/templates/base.html
+++ b/committeeoversightapp/templates/base.html
@@ -1,4 +1,5 @@
 {% load staticfiles %}
+{% load wagtailuserbar %}
 
 <!doctype html>
 <html lang="en">
@@ -20,10 +21,10 @@
 
 
     <!-- CSS -->
+    <link rel="stylesheet" href="{% static 'css/custom.css' %}">
     <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
     <link rel="stylesheet" href="{% static 'css/dataTables.bootstrap4.min.css' %}">
     <link rel="stylesheet" href="{% static 'css/select2.min.css' %}">
-    <link rel="stylesheet" href="{% static 'css/custom.css' %}">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
 
     <title>Committee Oversight Data Tool</title>
@@ -59,6 +60,7 @@
 
     <div class="container">
       <div class="row justify-content-center">
+          {% wagtailuserbar %}
           {% block content %}
           {% endblock %}
       </div>


### PR DESCRIPTION
## Overview

Closes #75. A lil PR to add the Wagtail userbar, a handy widget that allows authorized users to go directly to the Wagtail editing interface of a page. Should show up in the bottom right corner, like this:

<img width="803" alt="Screen Shot 2019-09-11 at 4 44 10 PM" src="https://user-images.githubusercontent.com/1094243/64737928-9a089900-d4b3-11e9-8d8f-94f81f05dd96.png">

## Testing Instructions

* Follow instructions in the README to get the app running
* If you don't already have one, create a category page in Wagtail
* Navigate to its live view and make sure you see the userbar!