### PR TITLE
Add crontask to back up database

### DIFF
--- a/scripts/after_install.sh
+++ b/scripts/after_install.sh
@@ -55,4 +55,9 @@ fi
 
 $venv_dir/bin/python $project_dir/scripts/render_configs.py $DEPLOYMENT_ID $DEPLOYMENT_GROUP_NAME
 
+# Move crontask to correct place, and assign correct ownership and permissions.
+mv $project_dir/scripts/committee-oversight-crontasks /etc/cron.d/committee-oversight-crontasks
+chown root.root /etc/cron.d/committee-oversight-crontasks
+chmod 644 /etc/cron.d/committee-oversight-crontasks
+
 echo "DEPLOYMENT_ID='$DEPLOYMENT_ID'" > $project_dir/committeeoversightapp/deployment.py

--- a/scripts/committee-oversight-crontasks
+++ b/scripts/committee-oversight-crontasks
@@ -1,0 +1,5 @@
+# /etc/cron.d/committee-oversight-crontasks
+
+# Back up the hearings database at midnight GMT every Thursday.
+# N.b., Thursday is arbitrary. Once weekly is the intent.
+0 0 * * 4 pg_dump -Fc -U postgres -d hearings | /usr/bin/aws s3 cp - s3://datamade-postgresql-backups/hearings/$(date -d "today" +"%Y%m%d%H%M").dump

--- a/scripts/committee-oversight-crontasks
+++ b/scripts/committee-oversight-crontasks
@@ -1,5 +1,4 @@
 # /etc/cron.d/committee-oversight-crontasks
 
-# Back up the hearings database at midnight GMT every Thursday.
-# N.b., Thursday is arbitrary. Once weekly is the intent.
+# Back up the hearings database at midnight GMT every day.
 0 0 * * * pg_dump -Fc -U postgres -d hearings | /usr/bin/aws s3 cp - s3://datamade-postgresql-backups/hearings/$(date -d "today" +"%Y%m%d%H%M").dump

--- a/scripts/committee-oversight-crontasks
+++ b/scripts/committee-oversight-crontasks
@@ -2,4 +2,4 @@
 
 # Back up the hearings database at midnight GMT every Thursday.
 # N.b., Thursday is arbitrary. Once weekly is the intent.
-0 0 * * 4 pg_dump -Fc -U postgres -d hearings | /usr/bin/aws s3 cp - s3://datamade-postgresql-backups/hearings/$(date -d "today" +"%Y%m%d%H%M").dump
+0 0 * * * pg_dump -Fc -U postgres -d hearings | /usr/bin/aws s3 cp - s3://datamade-postgresql-backups/hearings/$(date -d "today" +"%Y%m%d%H%M").dump


### PR DESCRIPTION
## Overview

Closes #63.

This pull request adds a crontask to back up the database once per ~week~ day. It follows the database backup strategy [outlined in our deployment documentation](https://github.com/datamade/deploy-a-site/blob/master/Backups.md) (internal link).

## Testing Instructions

* Shell into the staging server and run `pg_dump -Fc -U postgres -d hearings | /usr/bin/aws s3 cp - s3://datamade-postgresql-backups/hearings/$(date -d "today" +"%Y%m%d%H%M").dump`.
* Navigate to the `datamade-postgresql-backups` bucket in the S3 console and confirm that a new backup was made in the `hearings` directory.
* Check that I spelled `committee-oversight-crontasks` right in the update to `after_install`. 😅
