### PR TITLE
Dump data for custom Wagtail page models

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ docker-compose run --rm app python manage.py load_cms_content
 1. Back up the CMS content (except for image files):
 
     ```bash
-    docker-compose run --rm app python manage.py dumpdata --natural-foreign --indent 2 -e core -e legislative -e committeeoversightapp -e contenttypes -e auth.permission -e wagtailcore.groupcollectionpermission -e wagtailcore.grouppagepermission -e wagtailimages.rendition -e sessions > committeeoversightapp/fixtures/initial_cms_content.json
+    docker-compose run --rm app python manage.py dumpdata --natural-foreign --indent 2 -e core -e legislative -e committeeoversightapp -e contenttypes -e auth.permission -e wagtailcore.groupcollectionpermission -e wagtailcore.grouppagepermission -e wagtailimages.rendition -e sessions > committeeoversightapp/fixtures/initial_cms_content.json && docker-compose run --rm app python manage.py dumpdata --natural-foreign --indent 2 committeeoversightapp.landingpage committeeoversightapp.staticpage committeeoversightapp.categorydetailpage > committeeoversightapp/fixtures/initial_cms_content_custom_pages.json
     ```
 
     This should update the `initial_cms_content.json` file in your `committeeoversightapp/fixtures`

--- a/committeeoversightapp/fixtures/initial_cms_content.json
+++ b/committeeoversightapp/fixtures/initial_cms_content.json
@@ -110,7 +110,7 @@
   "pk": 2,
   "fields": {
     "password": "pbkdf2_sha256$120000$sXnhQsPOX3xH$p9zCsIxzrHeoNDYMd5opN0wepivXUckwG5FI42jMEqo=",
-    "last_login": "2019-09-18T22:31:52.902Z",
+    "last_login": "2019-09-18T22:02:30.328Z",
     "is_superuser": true,
     "username": "testuser",
     "first_name": "",

--- a/committeeoversightapp/fixtures/initial_cms_content_custom_pages.json
+++ b/committeeoversightapp/fixtures/initial_cms_content_custom_pages.json
@@ -1,0 +1,16 @@
+[
+{
+  "model": "committeeoversightapp.landingpage",
+  "pk": 3,
+  "fields": {
+    "body": "<p>Lorem ipsum dolor sit amet, <b>consectetur adipiscing elit</b>. Cras ac nibh tristique, cursus enim eu, ullamcorper libero. Mauris laoreet leo sapien. <b>In ultricies sapien sed pellentesque finibus</b>. Nulla ac libero enim. Vestibulum ante ipsum primis in faucibus orci luctus, <b>et ultrices posuere cubil.</b></p>"
+  }
+},
+{
+  "model": "committeeoversightapp.staticpage",
+  "pk": 4,
+  "fields": {
+    "body": "[{\"type\": \"paragraph\", \"value\": \"<p>For the House Committee on Science, Space, and Technology</p>\", \"id\": \"8ff373de-7271-4939-abca-25de2c2157fd\"}]"
+  }
+}
+]

--- a/committeeoversightapp/management/commands/load_cms_content.py
+++ b/committeeoversightapp/management/commands/load_cms_content.py
@@ -15,6 +15,7 @@ class Command(BaseCommand):
         project_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
         fixtures_dir = os.path.join(project_dir, 'fixtures')
         initial_data_file = os.path.join(fixtures_dir, 'initial_cms_content.json')
+        initial_data_file_custom_pages = os.path.join(fixtures_dir, 'initial_cms_content_custom_pages.json')
 
         # Wagtail creates default Site and Page instances during install, but we already have
         # them in the data load. Remove the auto-generated ones.
@@ -24,6 +25,7 @@ class Command(BaseCommand):
             Page.objects.get(title='Welcome to your new Wagtail site!').delete()
 
         call_command('loaddata', initial_data_file, verbosity=0)
+        call_command('loaddata', initial_data_file_custom_pages, verbosity=0)
 
         print("Initial data loaded!")
 


### PR DESCRIPTION
## Overview

I pushed #82 to staging and found a 500 error! After installing Sentry for better debugging (#86), I saw that the site was throwing [this error](https://sentry.io/organizations/datamade/issues/1238794051/?project=1758781&referrer=slack):

```
LandingPage.DoesNotExist
LandingPage matching query does not exist.
```

I sshed into the staging server `hearings` database and realized the `committeeoversightapp_landingpage` table was empty. Which makes sense, because we're not dumping it in the instructions in the README! Custom Wagtail pages will need to be explicitly named there, exported, and then added to the management command. I've done that here. @hancush if this sounds reasonable to you I'd like to merge this to test on the staging server.
