### PR TITLE
Escape percent characters in cron tab

### DIFF
--- a/scripts/committee-oversight-crontasks
+++ b/scripts/committee-oversight-crontasks
@@ -1,4 +1,4 @@
 # /etc/cron.d/committee-oversight-crontasks
 
-# Back up the hearings database at midnight GMT every day.
-0 0 * * * (pg_dump -Fc -U postgres -d hearings | /usr/bin/aws s3 cp - s3://datamade-postgresql-backups/hearings/$(date -d "today" +"%Y%m%d%H%M").dump) && echo "staging backup $(date -d "today" +"%Y%m%d%H%M").dump complete" >> /tmp/committee-oversight-crontasks.log 2>&1
+# Back up the hearings database at 2:30 PM GMT every day.
+30 14 * * * (pg_dump -Fc -U postgres -d hearings | /usr/bin/aws s3 cp - s3://datamade-postgresql-backups/hearings/$(date -d "today" +"\%Y\%m\%d\%H\%M").dump) && echo "staging backup $(date -d "today" +"\%Y\%m\%d\%H\%M").dump complete" >> /tmp/committee-oversight-crontasks.log 2>&1


### PR DESCRIPTION
## Overview

Related to #79.

Cron treats all percent characters as newlines. This PR escapes all of them, in the hopes that this solves our cron woes.
