### PR TITLE
Committee Detail pages

### DIFF
--- a/committeeoversightapp/static/css/custom.css
+++ b/committeeoversightapp/static/css/custom.css
@@ -1,6 +1,7 @@
 :root {
   --lightest-blue-color: #fafcff;
   --light-blue-color: #e8eef9;
+  --blue-color: #3774bb;
   --dark-blue-color: #002f67;
   --darkest-blue-color: #001f43;
   --light-gray-color: #ced4da;
@@ -333,7 +334,7 @@ input[type='checkbox'] {
 .progress {
   background: var(--lightest-blue-color);
   border-radius: 17px;
-  height: 1.7rem;
+  height: 1.5rem;
   box-shadow: inset 0 2px 2px rgba(0, 0, 0, 0.1);
 }
 

--- a/committeeoversightapp/static/css/custom.css
+++ b/committeeoversightapp/static/css/custom.css
@@ -330,6 +330,13 @@ input[type='checkbox'] {
     content: '- Read Less';
 }
 
+.progress {
+  background: var(--lightest-blue-color);
+  border: .5px solid var(--dark-gray-color);
+  border-radius: 17px;
+  height: 1.7rem;
+}
+
 .list-item a {
   color: var(--dark-gray-color);
   font-weight: 600;

--- a/committeeoversightapp/static/css/custom.css
+++ b/committeeoversightapp/static/css/custom.css
@@ -142,6 +142,11 @@ h4 {
   font-size: 14px;
 }
 
+.btn-center {
+  text-align:center;
+  display:block;
+}
+
 .edit-buttons {
   padding-top: 45px;
 }
@@ -303,6 +308,26 @@ input[type='checkbox'] {
 .rating-large {
   font-size: 3rem;
   font-weight: 900;
+}
+
+#summary div.collapse:not(.show) {
+    height: 14rem !important;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 11;
+    -webkit-box-orient: vertical;
+}
+
+#summary div.collapsing {
+    min-height: 220px !important;
+}
+
+#summary a.collapsed:after  {
+    content: '+ Read More';
+}
+
+#summary a:not(.collapsed):after {
+    content: '- Read Less';
 }
 
 .list-item a {

--- a/committeeoversightapp/static/css/custom.css
+++ b/committeeoversightapp/static/css/custom.css
@@ -332,9 +332,30 @@ input[type='checkbox'] {
 
 .progress {
   background: var(--lightest-blue-color);
-  border: .5px solid var(--dark-gray-color);
   border-radius: 17px;
   height: 1.7rem;
+  box-shadow: inset 0 2px 2px rgba(0, 0, 0, 0.1);
+}
+
+.progress-bar {
+  background-size: 6px 6px;
+  opacity: 0.9;
+}
+
+.progress-bar-neutral {
+  background-color: var(--dark-blue-color);
+}
+
+.progress-bar-green {
+  background-color: var(--green-color);
+}
+
+.progress-bar-orange {
+  background-color: var(--orange-color);
+}
+
+.progress-bar-red {
+  background-color: var(--red-color);
 }
 
 .list-item a {

--- a/committeeoversightapp/static/css/custom.css
+++ b/committeeoversightapp/static/css/custom.css
@@ -116,6 +116,10 @@ h4 {
   color: black;
 }
 
+td {
+  vertical-align: middle!important;
+}
+
 .btn-primary {
   background-color: var(--dark-blue-color);
   border-color: var(--dark-blue-color);

--- a/committeeoversightapp/static/css/custom.css
+++ b/committeeoversightapp/static/css/custom.css
@@ -300,6 +300,11 @@ input[type='checkbox'] {
   font-weight: 600;
 }
 
+.rating-large {
+  font-size: 3rem;
+  font-weight: 900;
+}
+
 .list-item a {
   color: var(--dark-gray-color);
   font-weight: 600;

--- a/committeeoversightapp/static/js/chart_helper.js
+++ b/committeeoversightapp/static/js/chart_helper.js
@@ -1,0 +1,77 @@
+Highcharts.setOptions({
+    lang: {
+        thousandsSep: ','
+    },
+    chart: {
+        style: {
+            fontFamily: '"Roboto", sans-serif'
+        }
+    }
+});
+
+var ChartHelper = ChartHelper || {};
+var ChartHelper = {
+    make_column_chart: function(el,
+        categories,
+        series_data,
+        title_text,
+        historical_average,
+        bar_color) {
+      $(el).highcharts({
+        chart: {
+            type: 'column'
+        },
+        title: {
+            text: title_text
+        },
+        xAxis: {
+            categories: categories,
+            title: {
+                text: 'Congress'
+            }
+        },
+        yAxis: {
+            min: 0,
+            title: {
+                text: null,
+                align: 'high'
+            },
+            labels: {
+                overflow: 'justify'
+            },
+            stackLabels: {
+              enabled: false,
+            },
+            allowDecimals: false,
+            plotLines: [{
+                value: historical_average,
+                color: '#c2682a',
+                dashStyle: 'shortdash',
+                width: 2,
+            }]
+        },
+        tooltip: {
+          enabled: false,
+        },
+        plotOptions: {
+            series: {
+                dataLabels: {
+                    enabled: true,
+                },
+                borderRadius: 2,
+            }
+        },
+        credits: {
+            enabled: false
+        },
+        series: [{
+            data: series_data,
+            color: bar_color,
+        }],
+        legend: {
+          enabled: false,
+        },
+      });
+
+    }
+}

--- a/committeeoversightapp/templates/404.html
+++ b/committeeoversightapp/templates/404.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
+<div class="row justify-content-center">
   <div class="col-12 col-lg-9 mx-auto">
     <h2 class="mb-4">Nothing to see here yet!</h2>
     <p>
@@ -8,5 +9,5 @@
       <a href="/committee-61caba6d-71bc-41c7-882e-32ec97768f63/">House Committee on Science, Space, and Technology</a>?
     </p>
   </div>
-
+</div>
 {% endblock %}

--- a/committeeoversightapp/templates/base.html
+++ b/committeeoversightapp/templates/base.html
@@ -19,6 +19,7 @@
     <script type="text/javascript" src="{% static 'js/jquery.formset.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/jquery.dataTables.min.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/dataTables.bootstrap4.min.js' %}"></script>
+    {% block extra_js %}{% endblock %}
 
 
     <!-- CSS -->

--- a/committeeoversightapp/templates/base.html
+++ b/committeeoversightapp/templates/base.html
@@ -41,7 +41,7 @@
 
     {% wagtailuserbar %}
 
-    <div class="container justify-content-center">
+    <div class="container">
       {% block content %}
       {% endblock %}
     </div>

--- a/committeeoversightapp/templates/base.html
+++ b/committeeoversightapp/templates/base.html
@@ -29,7 +29,7 @@
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
     <link href="https://fonts.googleapis.com/css?family=Roboto+Slab:300,400|Roboto:300,400,400i,500,700,700i&display=swap" rel="stylesheet">
 
-    <title>Committee Oversight Data Tool</title>
+    <title>{{page.title}}</title>
   </head>
 
   <body>
@@ -39,15 +39,14 @@
       {% top_menu parent=site_root calling_page=self %}
     {% endblock %}
 
-    <div class="container">
-      <div class="row justify-content-center">
-          {% wagtailuserbar %}
-          {% block content %}
-          {% endblock %}
-      </div>
+    {% wagtailuserbar %}
+
+    <div class="container justify-content-center">
+      {% block content %}
+      {% endblock %}
     </div>
 
   {% include "partials/footer.html" %}
-  
+
   </body>
 </html>

--- a/committeeoversightapp/templates/committeeoversightapp/category_detail_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/category_detail_page.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
+<div class="row justify-content-center">
   <div class="col-12 col-lg-9 mx-auto">
     <h2 class="mb-4 text-center">Category {{page.category.id}}: {{page.category.name}}</h2>
   </div>
@@ -8,6 +9,7 @@
   {% include 'partials/streamfield.html'%}
 
   {% include 'partials/hearing_table.html' %}
+</div>
 
   <script>
   $(document).ready(function () {

--- a/committeeoversightapp/templates/committeeoversightapp/committee_detail_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/committee_detail_page.html
@@ -36,13 +36,49 @@
    </div>
   </div>
 
+  <div class="card col-12 col-xl-10 mx-auto card-shadow">
+    <h4 class="text-center mt-4">
+      Current Committee
+    </h4>
+    <div class="card-body">
+      <!-- % of the way through current Congress -->
+        <div class="progress my-2">
+          <div class="progress-bar" role="progressbar" style="width: 92%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
+        </div>
+
+      <!-- Investigative Oversight hearings -->
+      <div class="progress my-2">
+        <div class="progress-bar btn-danger" role="progressbar" style="width: 23%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
+      </div>
+
+      <!-- Policy/Legislative hearings -->
+      <div class="progress my-2">
+        <div class="progress-bar btn-success" role="progressbar" style="width: 91%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
+      </div>
+
+      <!-- Total hearings -->
+      <div class="progress my-2">
+        <div class="progress-bar btn-edit" role="progressbar" style="width: 60%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
+      </div>
+
+    </div>
+  </div>
+
   <div class="card mt-5 col-12 col-xl-10 mx-auto card-shadow">
     <h4 class="text-center mt-4">
       Committee History
     </h4>
-    <div class="card-body">
+
+    <div class="card-body my-2">
       {% include 'partials/rating_table.html' %}
     </div>
+
+    <h4 class="text-center my-2">
+      Number of Hearings
+    </h4>
+
+    <!-- Bar charts go here -->
+    <div class="my-2"></div>
   </div>
 
   <div class="card mt-5 col-12 col-xl-10 mx-auto card-shadow">

--- a/committeeoversightapp/templates/committeeoversightapp/committee_detail_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/committee_detail_page.html
@@ -38,27 +38,43 @@
 
   <div class="card col-12 col-xl-10 mx-auto card-shadow">
     <h4 class="text-center mt-4">
-      Current Committee
+      Current Congress
     </h4>
     <div class="card-body">
       <!-- % of the way through current Congress -->
+        <p class="pl-2 text-center">
+          We are <span class="font-weight-bold">TK%</span> of the way through the 116th Congress
+        </p>
         <div class="progress my-2">
-          <div class="progress-bar" role="progressbar" style="width: 92%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
+          <div class="progress-bar progress-bar-striped progress-bar-neutral" role="progressbar" style="width: 92%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
         </div>
 
+      <p class="pl-2 pt-2 text-center font-weight-bold">
+        {{ page.title }}
+      </p>
+
       <!-- Investigative Oversight hearings -->
+      <small class="pl-2">
+        <span class="font-weight-bold">TK</span> Oversight Hearings; <span class="font-weight-bold">TK%</span> historical maximum
+      </small>
       <div class="progress my-2">
-        <div class="progress-bar btn-danger" role="progressbar" style="width: 23%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
+        <div class="progress-bar progress-bar-striped progress-bar-red" role="progressbar" style="width: 23%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
       </div>
 
       <!-- Policy/Legislative hearings -->
+      <small class="pl-2">
+        <span class="font-weight-bold">TK</span> Policy/Legislative Hearings; <span class="font-weight-bold">TK%</span> historical maximum
+      </small>
       <div class="progress my-2">
-        <div class="progress-bar btn-success" role="progressbar" style="width: 91%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
+        <div class="progress-bar progress-bar-striped progress-bar-green" role="progressbar" style="width: 91%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
       </div>
 
       <!-- Total hearings -->
+      <small class="pl-2">
+        <span class="font-weight-bold">TK</span> Total Hearings; <span class="font-weight-bold">TK%</span> historical maximum
+      </small>
       <div class="progress my-2">
-        <div class="progress-bar btn-edit" role="progressbar" style="width: 60%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
+        <div class="progress-bar progress-bar-striped progress-bar-orange" role="progressbar" style="width: 60%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
       </div>
 
     </div>

--- a/committeeoversightapp/templates/committeeoversightapp/committee_detail_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/committee_detail_page.html
@@ -1,18 +1,33 @@
 {% extends "base.html" %}
 
 {% block content %}
-  <div class="col-12 text-center">
-    <h2 class="mb-4">{{ page.title }}</h2>
-    <p class="lead font-weight-light text-dark"><strong>Chairperson:</strong> John Smith</p>
+  <div class="row justify-content-center">
+    <div class="col-12 col-lg-10 text-center">
+      <h2 class="my-2">{{ page.title }}</h2>
+      <p class="lead font-weight-light mb-2 mt-3"><strong>Chair: </strong> {{ page.chair }}</p>
+    </div>
   </div>
 
-  <div class="col-md-6 my-3 font-weight-light">
-    {{ page.body|safe }}
+  <div class="row justify-content-center align-items-center">
+    <div class="col-6 col-md-4 col-lg-3 col-xl-3 my-3 pr-4 text-right border-right">
+      <h3 class="rating-large b-plus-rating">B+</h3>
+      <p>
+        Projected CHP Score for the 116th Congress<br />
+        <small><i>Last updated: {% now "jS F Y H:i" %}</i></small>
+      </p>
+    </div>
+
+    <div class="col-6 col-md-5 col-lg-4 col-xl-3 my-3 pl-4 text-left">
+      <p class="font-weight-light my-2"><strong>3</strong> Investigative Oversight Hearings</p>
+      <p class="font-weight-light my-2"><strong>15</strong> Policy/Legislative Hearings</p>
+      <p class="font-weight-light my-2"><strong>43</strong> Total Hearings</p>
+    </div>
   </div>
-  <div class="col-md-6 my-3">
-    <h4>Projected CHP Score for the 116th Congress:</h4>
-    <h3 class="rating b-plus-rating">B+</h3>
-    <small>Last updated: {% now "jS F Y H:i" %}</small>
+
+  <div class="row justify-content-center">
+    <div class="col-12 col-lg-10 col-xl-6 my-2 font-weight-light">
+      {{ page.body|safe }}
+    </div>
   </div>
 
   <div class="col-12">

--- a/committeeoversightapp/templates/committeeoversightapp/committee_detail_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/committee_detail_page.html
@@ -2,7 +2,7 @@
 
 {% block content %}
   <div class="row justify-content-center">
-    <div class="col-12 col-lg-10 text-center">
+    <div class="col-12 col-md-10 text-center">
       <h2 class="my-2">{{ page.title }}</h2>
       <p class="lead font-weight-light mb-2 mt-3"><strong>Chair: </strong> {{ page.chair }}</p>
     </div>
@@ -18,27 +18,41 @@
     </div>
 
     <div class="col-6 col-md-5 col-lg-4 col-xl-3 my-3 pl-4 text-left">
-      <p class="font-weight-light my-2"><strong>3</strong> Investigative Oversight Hearings</p>
-      <p class="font-weight-light my-2"><strong>15</strong> Policy/Legislative Hearings</p>
-      <p class="font-weight-light my-2"><strong>43</strong> Total Hearings</p>
+      <p class="font-weight-light my-2"><strong>TK</strong> Investigative Oversight Hearings</p>
+      <p class="font-weight-light my-2"><strong>TK</strong> Policy/Legislative Hearings</p>
+      <p class="font-weight-light my-2"><strong>TK</strong> Total Hearings</p>
     </div>
   </div>
 
   <div class="row justify-content-center">
-    <div class="col-12 col-lg-10 col-xl-6 my-2 font-weight-light">
-      {{ page.body|safe }}
+   <div class="col-12 col-lg-10 col-xl-6 my-2 font-weight-light">
+     <div id="summary">
+       <div class="collapse" id="collapseSummary">
+         {{ page.body|safe }}
+       </div>
+       <a class="collapsed btn btn-back btn-center my-3" data-toggle="collapse" href="#collapseSummary" aria-expanded="false" aria-controls="collapseSummary"></a>
+     </div>
+     <hr />
+   </div>
+  </div>
+
+  <div class="card mt-5 col-12 col-xl-10 mx-auto card-shadow">
+    <h4 class="text-center mt-4">
+      Committee History
+    </h4>
+    <div class="card-body">
+      {% include 'partials/rating_table.html' %}
     </div>
   </div>
 
-  <div class="col-12">
-    {% include 'partials/rating_table.html' %}
-  </div>
-
-  <div class="col-sm-9 justify-content-left pt-5">
-    <h4 style="margin-bottom: -25px;">
-      Hearings held by the<br />{{ page.committee.name }}
+  <div class="card mt-5 col-12 col-xl-10 mx-auto card-shadow">
+    <h4 class="text-center mt-4">
+      Hearings held by the <br />
+      {{ page.title }}
     </h4>
-    {% include 'partials/hearing_table.html' %}
+    <div class="card-body">
+      {% include 'partials/hearing_table.html' %}
+    </div>
   </div>
 
   <script>

--- a/committeeoversightapp/templates/committeeoversightapp/committee_detail_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/committee_detail_page.html
@@ -31,7 +31,7 @@
   </div>
 
   <div class="row justify-content-center">
-   <div class="col-12 col-lg-10 col-xl-6 my-2 font-weight-light">
+   <div class="col-12 col-lg-10 col-xl-7 my-2 font-weight-light">
      <div id="summary">
        <div class="collapse" id="collapseSummary">
          {{ page.body|safe }}
@@ -106,15 +106,15 @@
 
     <div class="my-4 row">
 
-      <div class="col-4">
+      <div class="col-md-4">
         <div id="chart_investigative_oversight" style='height: 20rem'></div>
       </div>
 
-      <div class="col-4">
+      <div class="col-md-4">
         <div id="chart_policy" style='height: 20rem'></div>
       </div>
 
-      <div class="col-4">
+      <div class="col-md-4">
         <div id="chart_total" style='height: 20rem'></div>
       </div>
 

--- a/committeeoversightapp/templates/committeeoversightapp/committee_detail_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/committee_detail_page.html
@@ -1,4 +1,10 @@
 {% extends "base.html" %}
+{% load static %}
+
+{% block extra_js %}
+  <script src="https://code.highcharts.com/highcharts.js"></script>
+  <script src="{% static 'js/chart_helper.js' %}"></script>
+{% endblock %}
 
 {% block content %}
   <div class="row justify-content-center">
@@ -89,12 +95,30 @@
       {% include 'partials/rating_table.html' %}
     </div>
 
-    <h4 class="text-center my-2">
+    <h4 class="text-center my-3">
       Number of Hearings
     </h4>
 
-    <!-- Bar charts go here -->
-    <div class="my-2"></div>
+    <!-- Hearing count bar charts -->
+    <small class="text-center">
+      <span style="color:#c2682a;" class="font-weight-bold">---</span> Historical Average
+    </small>
+
+    <div class="my-4 row">
+
+      <div class="col-4">
+        <div id="chart_investigative_oversight" style='height: 20rem'></div>
+      </div>
+
+      <div class="col-4">
+        <div id="chart_policy" style='height: 20rem'></div>
+      </div>
+
+      <div class="col-4">
+        <div id="chart_total" style='height: 20rem'></div>
+      </div>
+
+    </div>
   </div>
 
   <div class="card mt-5 col-12 col-xl-10 mx-auto card-shadow">
@@ -108,6 +132,36 @@
   </div>
 
   <script>
+    $(function () {
+      var chart_id = '#chart_investigative_oversight'
+      var categories = ['111', '112', '113', '114', '115']
+      var series_data = [5, 6, 7, 8, 9]
+      var title_text = 'Investigative Oversight'
+      var historical_average = 7
+      var bar_color = '#3774bb'
+      ChartHelper.make_column_chart(chart_id, categories, series_data, title_text, historical_average, bar_color)
+    });
+
+    $(function () {
+      var chart_id = '#chart_policy'
+      var categories = ['111', '112', '113', '114', '115']
+      var series_data = [5, 6, 7, 8, 9]
+      var title_text = 'Policy/Legislative'
+      var historical_average = 7
+      var bar_color = '#002f67'
+      ChartHelper.make_column_chart(chart_id, categories, series_data, title_text, historical_average, bar_color)
+    });
+
+    $(function () {
+      var chart_id = '#chart_total'
+      var categories = ['111', '112', '113', '114', '115']
+      var series_data = [35, 26, 17, 28, 25]
+      var title_text = 'Total'
+      var historical_average = 26
+      var bar_color = '#001f43'
+      ChartHelper.make_column_chart(chart_id, categories, series_data, title_text, historical_average, bar_color)
+    });
+
     $(document).ready(function () {
         var committeeID = '{{ page.committee.id }}';
         function makeAjaxUrl(committeeID) {

--- a/committeeoversightapp/templates/committeeoversightapp/landing_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/landing_page.html
@@ -2,7 +2,6 @@
 {% load wagtailcore_tags %}
 
 {% block content %}
-
   <div class="row justify-content-center align-items-center">
     <div class="col-12 col-lg-6 col-xl-5 text-lg-right">
         <h2 class="mb-4 ml-3 dark-blue-color">{{page.title}}</h2>

--- a/committeeoversightapp/templates/committeeoversightapp/landing_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/landing_page.html
@@ -28,9 +28,9 @@
     </div>
   </div>
 
-  {% include "partials/landing_page_table.html" with committees=senate_committees title="The Senate"%}
+  {% include "partials/landing_page_table.html" with committees=house_committees title="House of Representatives"%}
 
-  {% include "partials/landing_page_table.html" with committees=house_committees title="The House of Representatives"%}
+  {% include "partials/landing_page_table.html" with committees=senate_committees title="Senate"%}
 
   <script>
     $(document).ready(function() {

--- a/committeeoversightapp/templates/committeeoversightapp/static_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/static_page.html
@@ -2,6 +2,7 @@
 {% load wagtailimages_tags %}
 
 {% block content %}
+<div class="row justify-content-center">
   <div class="text-center">
     {% image page.featured_image fill-1300x450 class="featured-image img-fluid mb-4" %}
   </div>
@@ -11,5 +12,6 @@
   </div>
 
   {% include 'partials/streamfield.html'%}
+</div>
 
 {% endblock %}

--- a/committeeoversightapp/templates/create.html
+++ b/committeeoversightapp/templates/create.html
@@ -2,30 +2,32 @@
 {% load static %}
 
 {% block content %}
-<div class="col col-lg-9">
-<script type="text/javascript">
-    $(document).ready(function() {
-      $('.basic-multiple').select2();
-    });
+<div class="row justify-content-center">
+  <div class="col col-lg-9">
+  <script type="text/javascript">
+      $(document).ready(function() {
+        $('.basic-multiple').select2();
+      });
 
-    $(function() {
-        $('#WitnessForm').formset();
-    })
-</script>
+      $(function() {
+          $('#WitnessForm').formset();
+      })
+  </script>
 
-<div class="hearing-form card">
-  <h2>Create New Hearing Record</h2>
-  <br />
-  <form method="POST" class="form">
+  <div class="hearing-form card">
+    <h2>Create New Hearing Record</h2>
+    <br />
+    <form method="POST" class="form">
 
-    {% include 'partials/hearing_form.html' %}
+      {% include 'partials/hearing_form.html' %}
 
-    <button type="submit" class="btn-lg btn-success float-right" id="save-hearing-button">
-      <i class="far fa-save"></i>&nbsp;
-      Save hearing
-    </button>
+      <button type="submit" class="btn-lg btn-success float-right" id="save-hearing-button">
+        <i class="far fa-save"></i>&nbsp;
+        Save hearing
+      </button>
 
-  </form>
-</div>
+    </form>
+  </div>
+  </div>
 </div>
 {% endblock %}

--- a/committeeoversightapp/templates/delete.html
+++ b/committeeoversightapp/templates/delete.html
@@ -1,30 +1,32 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<div class="col col-lg-11">
-<div class="hearing-form card">
-  <h2>Delete Hearing Record</h2>
-  <div class="float-right confirm-delete">
-    <i>Are you sure you want to delete this hearing?</i>
-  </div><br />
+<div class="row justify-content-center">
+  <div class="col col-lg-11">
+  <div class="hearing-form card">
+    <h2>Delete Hearing Record</h2>
+    <div class="float-right confirm-delete">
+      <i>Are you sure you want to delete this hearing?</i>
+    </div><br />
 
-  {% include 'partials/detail.html' %}
+    {% include 'partials/detail.html' %}
 
- <form method="POST" class="form">
-   {% csrf_token %}
-   <div class="float-right">
-     <a href="{% url 'list-event' %}" class="btn btn-back">
-       <i class="fas fa-arrow-circle-left"></i>&nbsp;
-       Back to list view
-     </a>
-     <button type="submit" class="btn btn-danger">
-       <i class="fas fa-times-circle"></i>&nbsp;
-       Delete hearing
-     </button>
-   </div>
- </form>
+   <form method="POST" class="form">
+     {% csrf_token %}
+     <div class="float-right">
+       <a href="{% url 'list-event' %}" class="btn btn-back">
+         <i class="fas fa-arrow-circle-left"></i>&nbsp;
+         Back to list view
+       </a>
+       <button type="submit" class="btn btn-danger">
+         <i class="fas fa-times-circle"></i>&nbsp;
+         Delete hearing
+       </button>
+     </div>
+   </form>
 
-</div>
+  </div>
+  </div>
 </div>
 
 {% endblock %}

--- a/committeeoversightapp/templates/edit.html
+++ b/committeeoversightapp/templates/edit.html
@@ -3,37 +3,39 @@
 {% load static %}
 
 {% block content %}
-<div class="col col-lg-9">
-<script type="text/javascript">
-    $(document).ready(function() {
-      $('.basic-multiple').select2();
-    });
+<div class="row justify-content-center">
+  <div class="col col-lg-9">
+  <script type="text/javascript">
+      $(document).ready(function() {
+        $('.basic-multiple').select2();
+      });
 
-    $(function() {
-        $('#WitnessForm .form-container').formset();
-    })
-</script>
+      $(function() {
+          $('#WitnessForm .form-container').formset();
+      })
+  </script>
 
-<div class="hearing-form card">
-  <h2>Edit Hearing Record</h2>
-  <br />
-  {% include 'partials/created_edited_dates.html' %}
-  <form method="POST" class="form">
+  <div class="hearing-form card">
+    <h2>Edit Hearing Record</h2>
+    <br />
+    {% include 'partials/created_edited_dates.html' %}
+    <form method="POST" class="form">
 
-    {% include 'partials/hearing_form.html' %}
+      {% include 'partials/hearing_form.html' %}
 
-    <div class="float-right edit-buttons">
-      <a href="{% url 'list-event' %}" class="btn btn-back">
-        <i class="fas fa-arrow-circle-left"></i>&nbsp;
-        Back to list view
-      </a>
-      <button type="submit" class="btn btn-edit">
-        <i class="fas fa-times-circle"></i>&nbsp;
-        Update hearing
-      </button>
-    </div>
+      <div class="float-right edit-buttons">
+        <a href="{% url 'list-event' %}" class="btn btn-back">
+          <i class="fas fa-arrow-circle-left"></i>&nbsp;
+          Back to list view
+        </a>
+        <button type="submit" class="btn btn-edit">
+          <i class="fas fa-times-circle"></i>&nbsp;
+          Update hearing
+        </button>
+      </div>
 
-  </form>
-</div>
+    </form>
+  </div>
+  </div>
 </div>
 {% endblock %}

--- a/committeeoversightapp/templates/list.html
+++ b/committeeoversightapp/templates/list.html
@@ -1,28 +1,30 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<div class="col">
-<div class="hearing-form card">
+<div class="row justify-content-center">
+  <div class="col">
+  <div class="hearing-form card">
 
- <p><a href="/" class="btn btn-success">Create new hearing</a></p>
- <p><i>The table below shows all scraped, imported, and manually entered hearings.</i></p>
+   <p><a href="/" class="btn btn-success">Create new hearing</a></p>
+   <p><i>The table below shows all scraped, imported, and manually entered hearings.</i></p>
 
- {% include 'partials/hearing_table.html' %}
+   {% include 'partials/hearing_table.html' %}
 
+  </div>
+  </div>
+
+  <script>
+  $(document).ready( function () {
+      $('#hearing-table').DataTable({
+        "dom": "Bfrtip",
+        "order": [[ 0, "desc" ]],
+        "columnDefs": [{ "orderable": false, "targets": [3, 4] }],
+        "processing": true,
+        "serverSide": true,
+        "ajax": "{% url 'order_list_json' %}"
+      });
+  } );
+  </script>
 </div>
-</div>
-
-<script>
-$(document).ready( function () {
-    $('#hearing-table').DataTable({
-      "dom": "Bfrtip",
-      "order": [[ 0, "desc" ]],
-      "columnDefs": [{ "orderable": false, "targets": [3, 4] }],
-      "processing": true,
-      "serverSide": true,
-      "ajax": "{% url 'order_list_json' %}"
-    });
-} );
-</script>
 
 {% endblock %}

--- a/committeeoversightapp/templates/partials/footer.html
+++ b/committeeoversightapp/templates/partials/footer.html
@@ -2,7 +2,7 @@
 
 <footer class="text-center mt-5">
 <a href="http://www.thelugarcenter.org/">
-  <img class="m-4" height="60" src="{% static 'images/logo.png' %}" />
+  <img class="mb-3 mt-1" height="60" src="{% static 'images/logo.png' %}" />
 </a>
 
 <p>

--- a/committeeoversightapp/templates/partials/hearing_table.html
+++ b/committeeoversightapp/templates/partials/hearing_table.html
@@ -1,4 +1,4 @@
-<table class="table table-striped table-borderless" id="hearing-table">
+<table class="table table-striped table-borderless table-sm" id="hearing-table">
  <thead>
    <tr>
      <th scope="col">Date Updated</th>

--- a/committeeoversightapp/templates/partials/hearing_table.html
+++ b/committeeoversightapp/templates/partials/hearing_table.html
@@ -1,13 +1,20 @@
-<table class="table table-striped table-borderless table-sm" id="hearing-table">
- <thead>
-   <tr>
-     <th scope="col">Date Updated</th>
-     <th scope="col" class="hearing-title-col">Hearing Title</th>
-     <th scope="col">Hearing Date</th>
-     <th scope="col">Edit</th>
-     <th scope="col">Delete</th>
-   </tr>
- </thead>
- <tbody>
- </tbody>
- </table>
+<div class="table-responsive">
+  <table class="table table-striped table-borderless table-sm" id="hearing-table">
+     <thead>
+       <tr>
+         <th scope="col">Date Updated</th>
+         <th scope="col" class="hearing-title-col">Hearing Title</th>
+         <th scope="col">Hearing Date</th>
+         {% if request.user.is_superuser %}
+           <th scope="col">Edit</th>
+           <th scope="col">Delete</th>
+         {% else %}
+           <th scope="col" style="visibility:collapse;"></th>
+           <th scope="col" style="visibility:collapse;"></th>
+         {% endif %}
+       </tr>
+     </thead>
+     <tbody>
+     </tbody>
+   </table>
+ </div>

--- a/committeeoversightapp/templates/partials/landing_page_table.html
+++ b/committeeoversightapp/templates/partials/landing_page_table.html
@@ -18,20 +18,20 @@
       <tbody>
           {% for committee in committees %}
           <tr>
-            <td class="list-item text-right align-middle pr-2"><a href="{{committee.url_id}}">{{committee.short_name}}</a></td>
+            <td class="list-item text-right pr-2"><a href="{{committee.url_id}}">{{committee.short_name}}</a></td>
               {% if committee.hide_rating %}
               <td class="align-middle">
                 N/A
               </td>
               {% else %}
-                <td class="rating {{committee.latest_rating.css_class}} align-middle">
+                <td class="rating {{committee.latest_rating.css_class}}">
                   {{committee.latest_rating}}
                 </td>
               {% endif %}
-            <td class="align-middle">{{committee.chair}}</td>
-            <td class="align-middle">5</td>
-            <td class="align-middle">10</td>
-            <td class="align-middle">15</td>
+            <td>{{committee.chair}}</td>
+            <td>5</td>
+            <td>10</td>
+            <td>15</td>
           </tr>
           {% endfor %}
       </tbody>

--- a/committeeoversightapp/templates/partials/rating_table.html
+++ b/committeeoversightapp/templates/partials/rating_table.html
@@ -1,37 +1,45 @@
 <div class="table-responsive">
-    <table class="table table-borderless table-striped text-center">
+    <table class="table table-borderless table-striped text-center table-sm">
         <thead>
             <tr>
                 <td></td>
-                <td colspan="2" class="font-weight-bold">
-                    Committee Performance
-                    <hr class="mb-0" />
-                </td>
                 <td colspan="3" class="font-weight-bold">
                     Number of Hearings
+                    <hr class="mb-0" />
+                </td>
+                <td colspan="2" class="font-weight-bold">
+                    Committee Hearing Performance
                     <hr class="mb-0" />
                 </td>
             </tr>
             <tr>
                 <td></td>
-                <td>CHP Score</td>
-                <td>Grade</td>
-                <td>Policy/Legislative</td>
                 <td>Investigative/Oversight</td>
+                <td>Policy/Legislative</td>
                 <td>Total Hearings</td>
+                <td>Score</td>
+                <td>Grade</td>
             </tr>
         </thead>
         <tbody>
             {% for rating in page.committee.committeerating_set.all %}
             <tr>
                 <td>Congress {{ rating.congress }}</td>
-                <td class="{{ rating.css_class }} font-weight-bold">{{ rating.rating }}</td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td class="{{ rating.css_class }} font-weight-bold lead">{{ rating.rating }}</td>
+            </tr>
+            {% endfor %}
+            <tr>
+                <td class="font-weight-bold">Historical average</td>
+                <td></td>
                 <td></td>
                 <td></td>
                 <td></td>
                 <td></td>
             </tr>
-            {% endfor %}
         </tbody>
     </table>
 </div>

--- a/committeeoversightapp/templates/partials/rating_table.html
+++ b/committeeoversightapp/templates/partials/rating_table.html
@@ -25,18 +25,18 @@
             {% for rating in page.committee.committeerating_set.all %}
             <tr>
                 <td>Congress {{ rating.congress }}</td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
+                <td>TK</td>
+                <td>TK</td>
+                <td>TK</td>
+                <td>TK</td>
                 <td class="{{ rating.css_class }} font-weight-bold lead">{{ rating.rating }}</td>
             </tr>
             {% endfor %}
             <tr>
                 <td class="font-weight-bold">Historical average</td>
-                <td></td>
-                <td></td>
-                <td></td>
+                <td class="font-weight-bold">TK</td>
+                <td class="font-weight-bold">TK</td>
+                <td class="font-weight-bold">TK</td>
                 <td></td>
                 <td></td>
             </tr>

--- a/committeeoversightapp/templates/partials/rating_table.html
+++ b/committeeoversightapp/templates/partials/rating_table.html
@@ -1,45 +1,45 @@
 <div class="table-responsive">
-    <table class="table table-borderless table-striped text-center table-sm">
-        <thead>
-            <tr>
-                <td></td>
-                <td colspan="3" class="font-weight-bold">
-                    Number of Hearings
-                    <hr class="mb-0" />
-                </td>
-                <td colspan="2" class="font-weight-bold">
-                    Committee Hearing Performance
-                    <hr class="mb-0" />
-                </td>
-            </tr>
-            <tr>
-                <td></td>
-                <td>Investigative/Oversight</td>
-                <td>Policy/Legislative</td>
-                <td>Total Hearings</td>
-                <td>Score</td>
-                <td>Grade</td>
-            </tr>
-        </thead>
-        <tbody>
-            {% for rating in page.committee.committeerating_set.all %}
-            <tr>
-                <td>Congress {{ rating.congress }}</td>
-                <td>TK</td>
-                <td>TK</td>
-                <td>TK</td>
-                <td>TK</td>
-                <td class="{{ rating.css_class }} font-weight-bold lead">{{ rating.rating }}</td>
-            </tr>
-            {% endfor %}
-            <tr>
-                <td class="font-weight-bold">Historical average</td>
-                <td class="font-weight-bold">TK</td>
-                <td class="font-weight-bold">TK</td>
-                <td class="font-weight-bold">TK</td>
-                <td></td>
-                <td></td>
-            </tr>
-        </tbody>
-    </table>
+  <table class="table table-borderless table-striped text-center table-sm">
+      <thead>
+          <tr>
+              <td></td>
+              <td colspan="3" class="font-weight-bold">
+                  Number of Hearings
+                  <hr class="mb-0" />
+              </td>
+              <td colspan="2" class="font-weight-bold">
+                  Committee Hearing Performance
+                  <hr class="mb-0" />
+              </td>
+          </tr>
+          <tr>
+              <td></td>
+              <td>Investigative/Oversight</td>
+              <td>Policy/Legislative</td>
+              <td>Total Hearings</td>
+              <td>Score</td>
+              <td>Grade</td>
+          </tr>
+      </thead>
+      <tbody>
+          {% for rating in page.committee.committeerating_set.all %}
+          <tr>
+              <td>Congress {{ rating.congress }}</td>
+              <td>TK</td>
+              <td>TK</td>
+              <td>TK</td>
+              <td>TK</td>
+              <td class="{{ rating.css_class }} font-weight-bold lead">{{ rating.rating }}</td>
+          </tr>
+          {% endfor %}
+          <tr>
+              <td class="font-weight-bold">Historical average</td>
+              <td class="font-weight-bold">TK</td>
+              <td class="font-weight-bold">TK</td>
+              <td class="font-weight-bold">TK</td>
+              <td></td>
+              <td></td>
+          </tr>
+      </tbody>
+  </table>
 </div>

--- a/committeeoversightapp/templates/registration/logged_out.html
+++ b/committeeoversightapp/templates/registration/logged_out.html
@@ -1,10 +1,12 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="col col-lg-8">
-<div class="hearing-form card">
-  <p>Logged out!</p>
-  <a href="{% url 'login'%}">Click here to login again.</a>
-</div>
+<div class="row justify-content-center">
+  <div class="col col-lg-8">
+  <div class="hearing-form card">
+    <p>Logged out!</p>
+    <a href="{% url 'login'%}">Click here to login again.</a>
+  </div>
+  </div>
 </div>
 {% endblock %}

--- a/committeeoversightapp/templates/registration/login.html
+++ b/committeeoversightapp/templates/registration/login.html
@@ -2,36 +2,38 @@
 {% load crispy_forms_tags %}
 
 {% block content %}
-<div class="col col-lg-8">
-<div class="hearing-form card">
-  {% if form.errors %}
-    <p>Your username and password didn't match. Please try again.</p>
-  {% endif %}
-
-  {% if next %}
-    {% if user.is_authenticated %}
-      <p>Your account doesn't have access to this page. To proceed,
-      please login with an account that has access.</p>
-    {% else %}
-      <p>Please sign in to see this page.</p>
+<div class="row justify-content-center">
+  <div class="col col-lg-8">
+  <div class="hearing-form card">
+    {% if form.errors %}
+      <p>Your username and password didn't match. Please try again.</p>
     {% endif %}
-  {% endif %}
 
-  <form method="post" action="{% url 'login' %}">
-  {% csrf_token %}
+    {% if next %}
+      {% if user.is_authenticated %}
+        <p>Your account doesn't have access to this page. To proceed,
+        please login with an account that has access.</p>
+      {% else %}
+        <p>Please sign in to see this page.</p>
+      {% endif %}
+    {% endif %}
 
-  <div>
-    <td>{{ form.username | as_crispy_field }}</td>
-  </div>
-  <div>
-    <td>{{ form.password | as_crispy_field }}</td>
-  </div>
+    <form method="post" action="{% url 'login' %}">
+    {% csrf_token %}
 
-  <div>
-    <input type="submit" class="btn btn-success float-right" value="Login" />
-    <input type="hidden" name="next" value="{{ next }}" />
+    <div>
+      <td>{{ form.username | as_crispy_field }}</td>
+    </div>
+    <div>
+      <td>{{ form.password | as_crispy_field }}</td>
+    </div>
+
+    <div>
+      <input type="submit" class="btn btn-success float-right" value="Login" />
+      <input type="hidden" name="next" value="{{ next }}" />
+    </div>
+    </form>
   </div>
-  </form>
-</div>
+  </div>
 </div>
 {% endblock %}

--- a/committeeoversightapp/views.py
+++ b/committeeoversightapp/views.py
@@ -107,14 +107,25 @@ class EventListJson(BaseDatatableView):
         edit_string = "<a href=\"/hearing/edit/{}\"><i class=\"fas fa fa-pencil-alt\" id=\"edit-icon\"></i></a>"
         delete_string = "<a href=\"/hearing/edit/{}\"><i class=\"fas fa fa-times-circle\" id=\"delete-icon\"></i></a>"
 
-        for item in qs:
-            json_data.append([
-                item.updated_at.strftime("%Y-%m-%d %I:%M%p %Z"),
-                item.name,
-                item.start_date,
-                edit_string.format(escape(item.pk)),
-                delete_string.format(escape(item.pk)),
-            ])
+        if self.request.user.is_authenticated:
+            for item in qs:
+                json_data.append([
+                    item.updated_at.strftime("%Y-%m-%d %I:%M%p %Z"),
+                    item.name,
+                    item.start_date,
+                    edit_string.format(escape(item.pk)),
+                    delete_string.format(escape(item.pk)),
+                ])
+        else:
+            for item in qs:
+                json_data.append([
+                    item.updated_at.strftime("%Y-%m-%d %I:%M%p %Z"),
+                    item.name,
+                    item.start_date,
+                    '',
+                    '',
+                ])
+
         return json_data
 
 


### PR DESCRIPTION
## Overview

Closes #66. The design of the committee detail pages—as far as we can get before introducing the data. Here's what it should look like: 

![screencapture-localhost-8000-committee-46d6937b-9758-4e9f-80ef-7e270c84e57e-2019-10-28-14_48_01](https://user-images.githubusercontent.com/1094243/67712461-040ccd00-f992-11e9-804d-8fd2c8a55748.png)

## Testing Instructions

 * If you don't already have it, set up/reset the site with the following steps:
	* Delete your volume (may not be necessary): `docker-compose down --volumes`
	* Start the site back up: `docker-compose up`
	* Open a new window and load `hearings.dump`:  `docker-compose exec postgres pg_restore -C -j4 --no-owner -U postgres -d hearings /app/hearings.dump`
	* Run migrations: `docker-compose exec app python manage.py migrate`
	* Load CMS content: `docker-compose run --rm app python manage.py load_cms_content`
	* Load sample committee ratings: `docker-compose run --rm app python manage.py load_committeeratings`
* Start up the site: `docker-compose up`
* Create a new committee page with a chairperson's name
* View it live at various sizes. Does it look good + like what you'd expect?