### PR TITLE
Category detail pages

### DIFF
--- a/committeeoversightapp/models.py
+++ b/committeeoversightapp/models.py
@@ -77,7 +77,7 @@ class HearingCategoryType(models.Model):
     name = models.CharField(max_length=100, primary_key=False)
 
     def __str__(self):
-        return u'({0}) {1}'.format(self.id, self.name)
+        return self.name
 
 
 class HearingCategory(models.Model):
@@ -85,9 +85,6 @@ class HearingCategory(models.Model):
     category = models.ForeignKey(HearingCategoryType,
                                  null=True,
                                  on_delete=models.CASCADE)
-
-    def __str__(self):
-        return 'Category {}: {}'.format(self.id, self.name)
 
 
 class WitnessDetails(models.Model):

--- a/committeeoversightapp/static/committeeoversightapp/js/detail_editor_slug.js
+++ b/committeeoversightapp/static/committeeoversightapp/js/detail_editor_slug.js
@@ -1,8 +1,11 @@
 $(function() {
   $('#id_category').on('change', function() {
       var value = this.value;
+      var text = this.options[this.selectedIndex].text;
+      
       var newSlug = "category-" + value;
-      var newSeoTitle = "Category " + value;
+      var newSeoTitle = "Category: " + text;
+
       $('#id_slug').val(newSlug);
       $('#id_seo_title').val(newSeoTitle);
   });

--- a/committeeoversightapp/static/js/detail_editor_slug.js
+++ b/committeeoversightapp/static/js/detail_editor_slug.js
@@ -1,9 +1,9 @@
 $(function() {
   $('#id_category').on('change', function() {
-      var value = this.value;
       var text = this.options[this.selectedIndex].text;
-      
-      var newSlug = "category-" + value;
+      var text_slug = slugify(text)
+
+      var newSlug = "category-" + text_slug;
       var newSeoTitle = "Category: " + text;
 
       $('#id_slug').val(newSlug);
@@ -32,4 +32,20 @@ try {
   } else {
     console.log('Did not find django.jQuery, skipping autocomplete listener')
   }
+}
+
+  // taken from https://gist.github.com/hagemann/382adfc57adbd5af078dc93feef01fe1#file-slugify-js
+function slugify(string) {
+  const a = 'àáâäæãåāăąçćčđďèéêëēėęěğǵḧîïíīįìłḿñńǹňôöòóœøōõőṕŕřßśšşșťțûüùúūǘůűųẃẍÿýžźż·/_,:;'
+  const b = 'aaaaaaaaaacccddeeeeeeeegghiiiiiilmnnnnoooooooooprrsssssttuuuuuuuuuwxyyzzz------'
+  const p = new RegExp(a.split('').join('|'), 'g')
+
+  return string.toString().toLowerCase()
+    .replace(/\s+/g, '-') // Replace spaces with -
+    .replace(p, c => b.charAt(a.indexOf(c))) // Replace special characters
+    .replace(/&/g, '-and-') // Replace & with 'and'
+    .replace(/[^\w\-]+/g, '') // Remove all non-word characters
+    .replace(/\-\-+/g, '-') // Replace multiple - with single -
+    .replace(/^-+/, '') // Trim - from start of text
+    .replace(/-+$/, '') // Trim - from end of text
 }

--- a/committeeoversightapp/templates/committeeoversightapp/category_detail_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/category_detail_page.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="row justify-content-center">
-  <div class="col-12 col-lg-9 mx-auto text-center">
-    <h2 class="mb-4 text-center">Category: {{page.category}}</h2>
+  <div class="row justify-content-center">
+    <div class="col-12 col-lg-9 mx-auto text-center">
+      <h2 class="mb-4 text-center">Category: {{page.category}}</h2>
+    </div>
   </div>
 
   <div class="row justify-content-center">
@@ -23,7 +24,6 @@
       {% include 'partials/hearing_table.html' %}
     </div>
   </div>
-</div>
 
   <script>
   $(document).ready(function () {

--- a/committeeoversightapp/templates/committeeoversightapp/category_detail_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/category_detail_page.html
@@ -2,13 +2,27 @@
 
 {% block content %}
 <div class="row justify-content-center">
-  <div class="col-12 col-lg-9 mx-auto">
-    <h2 class="mb-4 text-center">Category {{page.category.id}}: {{page.category.name}}</h2>
+  <div class="col-12 col-lg-9 mx-auto text-center">
+    <h2 class="mb-4 text-center">Category: {{page.category}}</h2>
   </div>
 
-  {% include 'partials/streamfield.html'%}
+  <div class="row justify-content-center">
+   <div class="col-12 col-lg-10 col-xl-7 my-2 font-weight-light">
+     <div id="summary">
+       <div class="collapse" id="collapseSummary">
+         {{ page.body|safe }}
+       </div>
+       <a class="collapsed btn btn-back btn-center my-3" data-toggle="collapse" href="#collapseSummary" aria-expanded="false" aria-controls="collapseSummary"></a>
+     </div>
+     <hr />
+   </div>
+  </div>
 
-  {% include 'partials/hearing_table.html' %}
+  <div class="card mt-5 col-12 col-xl-10 mx-auto card-shadow">
+    <div class="card-body">
+      {% include 'partials/hearing_table.html' %}
+    </div>
+  </div>
 </div>
 
   <script>

--- a/committeeoversightapp/wagtail_hooks.py
+++ b/committeeoversightapp/wagtail_hooks.py
@@ -8,7 +8,7 @@ from wagtail.core import hooks
 @hooks.register('insert_editor_js')
 def editor_js():
     js_files = [
-        'committeeoversightapp/js/detail_editor_slug.js',
+        'js/detail_editor_slug.js',
     ]
     js_includes = format_html_join('\n', '<script src="{0}{1}"></script>',
         ((settings.STATIC_URL, filename) for filename in js_files)

--- a/docker-compose.db-ops.yml
+++ b/docker-compose.db-ops.yml
@@ -15,8 +15,6 @@ services:
   dbload-fixtures:
     container_name: committeeoversight-dbload-fixtures
     image: committeeoversight:latest
-    depends_on:
-      - dbload-dump
     volumes:
       - .:/app
       - ${PWD}/committeeoversight/local_settings.example.py:/app/committeeoversight/local_settings.py

--- a/docker-compose.db-ops.yml
+++ b/docker-compose.db-ops.yml
@@ -5,14 +5,19 @@ services:
     container_name: committeeoversight-dbload
     image: committeeoversight:latest
     depends_on:
-      - app
+      postgres:
+        condition: service_healthy
+      app:
+        condition: service_healthy
     volumes:
       - .:/app
       - ${PWD}/committeeoversight/local_settings.example.py:/app/committeeoversight/local_settings.py
-    # For some reason, Python logs are buffered if they don't come through
-    # logging. For instant reporting of non-logging output, i.e., print state-
-    # ments or writing to STDOUT directly, run python commands with the -u flag.
-    # https://github.com/moby/moby/issues/12447#issuecomment-263846539
+    command: 'true'
+
+  postgres:
+      command: pg_restore -C -j4 --no-owner -U postgres -d hearings /app/hearings.dump
+
+  app:
     command: >
       bash -c "python manage.py migrate &&
       python manage.py load_cms_content &&

--- a/docker-compose.db-ops.yml
+++ b/docker-compose.db-ops.yml
@@ -1,23 +1,25 @@
 version: '2.4'
 
 services:
-  dbload:
-    container_name: committeeoversight-dbload
-    image: committeeoversight:latest
+  dbload-dump:
+    container_name: committeeoversight-dbload-dump
+    image: mdillon/postgis:10
     depends_on:
-      postgres:
-        condition: service_healthy
-      app:
-        condition: service_healthy
+      - app
+      - postgres
     volumes:
       - .:/app
       - ${PWD}/committeeoversight/local_settings.example.py:/app/committeeoversight/local_settings.py
-    command: 'true'
+    command: pg_restore -C -j4 --no-owner -U postgres -d hearings -h postgres -p 5432 /app/hearings.dump
 
-  postgres:
-      command: pg_restore -C -j4 --no-owner -U postgres -d hearings /app/hearings.dump
-
-  app:
+  dbload-fixtures:
+    container_name: committeeoversight-dbload-fixtures
+    image: committeeoversight:latest
+    depends_on:
+      - dbload-dump
+    volumes:
+      - .:/app
+      - ${PWD}/committeeoversight/local_settings.example.py:/app/committeeoversight/local_settings.py
     command: >
       bash -c "python manage.py migrate &&
       python manage.py load_cms_content &&

--- a/docker-compose.db-ops.yml
+++ b/docker-compose.db-ops.yml
@@ -1,0 +1,20 @@
+version: '2.4'
+
+services:
+  dbload:
+    container_name: committeeoversight-dbload
+    image: committeeoversight:latest
+    depends_on:
+      - app
+    volumes:
+      - .:/app
+      - ${PWD}/committeeoversight/local_settings.example.py:/app/committeeoversight/local_settings.py
+    # For some reason, Python logs are buffered if they don't come through
+    # logging. For instant reporting of non-logging output, i.e., print state-
+    # ments or writing to STDOUT directly, run python commands with the -u flag.
+    # https://github.com/moby/moby/issues/12447#issuecomment-263846539
+    command: >
+      bash -c "python manage.py migrate &&
+      python manage.py load_cms_content &&
+      python manage.py load_committeeratings &&
+      python manage.py loaddata hearingcategorytype"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,11 +17,6 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    healthcheck:
-      test: ["CMD-SHELL", "python manage.py runserver 0.0.0.0:8000"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
     volumes:
       # Mount the development directory as a volume into the container, so
       # Docker automatically recognizes your changes.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,11 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "python manage.py runserver 0.0.0.0:8000"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     volumes:
       # Mount the development directory as a volume into the container, so
       # Docker automatically recognizes your changes.


### PR DESCRIPTION
## Overview

Closes #67 and #108. This PR adds a simple category detail page following the mockup styles: https://app.moqups.com/NUARyAts8L/view/page/ad113671c

It also adds two `db-ops` services to simplify the local testing process.


## Testing Instructions

 * Take down your Docker container: `docker-compose down --volumes`
*  Load data: `docker-compose -f docker-compose.yml -f docker-compose.db-ops.yml run -e PGPASSWORD=postgres --rm dbload-dump`
* Load fixtures: `docker-compose -f docker-compose.yml -f docker-compose.db-ops.yml run --rm dbload-fixtures`
* Run the site: `docker-compose up`
* Log into the site and create a new Category Detail Page
* Check that the title, and URL populate automatically as you'd expect
* Publish the page and look at it live. Make sure all looks good!
* Edit a hearing to give it the category whose page you made, and make sure it appears in the hearings table
