### PR TITLE
Add permanent committee list & fix JS slugify

### DIFF
--- a/committeeoversight/settings.py
+++ b/committeeoversight/settings.py
@@ -140,3 +140,50 @@ MEDIA_URL = '/media/'
 LOGIN_REDIRECT_URL = '/'
 
 WAGTAIL_SITE_NAME = 'Committee Oversight'
+
+CURRENT_PERMANENT_COMMITTEES = [
+    'House Committee on Agriculture',
+    'House Committee on Appropriations',
+    'House Committee on Armed Services',
+    'House Committee on Budget',
+    'House Committee on Education and the Workforce',
+    'House Committee on Energy and Commerce',
+    'House Committee on Financial Services',
+    'House Committee on Foreign Affairs',
+    'House Committee on Homeland Security',
+    'House Committee on House Administration',
+    'House Committee on Intelligence (Permanent Select)',
+    'House Committee on Judiciary',
+    'House Committee on Natural Resources',
+    'House Committee on Oversight and Government Reform',
+    'House Committee on Rules',
+    'House Committee on Science, Space, and Technology',
+    'House Committee on Small Business',
+    'House Committee on Transportation and Infrastructure',
+    'House Committee on Veterans\' Affairs',
+    'House Committee on Ways and Means',
+    'Senate Committee on Aging',
+    'Senate Committee on Agriculture, Nutrition, and Forestry',
+    'Senate Committee on Appropriations',
+    'Senate Committee on Armed Services',
+    'Senate Committee on Banking, Housing, and Urban Affairs',
+    'Senate Committee on Budget',
+    'Senate Committee on Commerce, Science, and Transportation',
+    'Senate Committee on Energy and Natural Resources',
+    'Senate Committee on Environment and Public Works',
+    'Senate Committee on Finance',
+    'Senate Committee on Foreign Relations',
+    'Senate Committee on Health, Education, Labor, and Pensions',
+    'Senate Committee on Homeland Security and Governmental Affairs',
+    'Senate Committee on Indian Affairs',
+    'Senate Committee on Intelligence',
+    'Senate Committee on Judiciary',
+    'Senate Committee on Rules and Administration',
+    'Senate Committee on Small Business and Entrepreneurship',
+    'Senate Committee on Veterans\' Affairs',
+]
+
+CHAMBERS = [
+    'United States House of Representatives',
+    'United States Senate'
+]

--- a/committeeoversightapp/models.py
+++ b/committeeoversightapp/models.py
@@ -218,7 +218,9 @@ class LandingPage(ResetMixin, Page):
     def get_context(self, request):
         context = super(LandingPage, self).get_context(request)
 
-        context['committees'] = CommitteeOrganization.objects.permanent_committees()
+        context['committees'] = CommitteeOrganization.objects \
+            .permanent_committees() \
+            .order_by('name')
 
         context['house_committees'] = context['committees'].filter(
             parent__name='United States House of Representatives'

--- a/committeeoversightapp/static/js/detail_editor_slug.js
+++ b/committeeoversightapp/static/js/detail_editor_slug.js
@@ -34,18 +34,13 @@ try {
   }
 }
 
-  // taken from https://gist.github.com/hagemann/382adfc57adbd5af078dc93feef01fe1#file-slugify-js
-function slugify(string) {
-  const a = 'àáâäæãåāăąçćčđďèéêëēėęěğǵḧîïíīįìłḿñńǹňôöòóœøōõőṕŕřßśšşșťțûüùúūǘůűųẃẍÿýžźż·/_,:;'
-  const b = 'aaaaaaaaaacccddeeeeeeeegghiiiiiilmnnnnoooooooooprrsssssttuuuuuuuuuwxyyzzz------'
-  const p = new RegExp(a.split('').join('|'), 'g')
-
-  return string.toString().toLowerCase()
-    .replace(/\s+/g, '-') // Replace spaces with -
-    .replace(p, c => b.charAt(a.indexOf(c))) // Replace special characters
-    .replace(/&/g, '-and-') // Replace & with 'and'
-    .replace(/[^\w\-]+/g, '') // Remove all non-word characters
-    .replace(/\-\-+/g, '-') // Replace multiple - with single -
-    .replace(/^-+/, '') // Trim - from start of text
-    .replace(/-+$/, '') // Trim - from end of text
-}
+  // taken from https://gist.github.com/mathewbyrne/1280286
+  // to match Django slugify
+  function slugify(text) {
+    return text.toString().toLowerCase()
+      .replace(/\s+/g, '-')           // Replace spaces with -
+      .replace(/[^\w\-]+/g, '')       // Remove all non-word chars
+      .replace(/\-\-+/g, '-')         // Replace multiple - with single -
+      .replace(/^-+/, '')             // Trim - from start of text
+      .replace(/-+$/, '');            // Trim - from end of text
+  }


### PR DESCRIPTION
## Overview

Closes #113. We need to display only the current permanent committees on the landing page, a list provided by Lugar. This PR adds that list as `CURRENT_PERMANENT_COMMITTEES`, a settings variable. It also adds `CHAMBERS` as another handy global variable.

In the process of putting together this PR, I realized that Django's slugify function and the JS I'm using don't exactly match up, specifically in their handling of the category "Meeting/Markup". I've corrected that inconsistency here as well.

There's one outstanding question that I've sent to Jamie and Dan: 

> This update is just about ready to push to the staging site, but I have a question about one committee: in the current data, we have a 'House Committee on Education and the Workforce.' Is that ok to sub in for 'House Committee on Education', or should we look into changing the data?

Question for @jeancochrane: what do you think about putting these things in `settings`? Is there a different place that you'd recommend?

## Testing Instructions

* Follow the instructions in the README to get the site running
* Make sure the landing page works and shows exactly 39 committees