### PR TITLE
Letter grade sort

### DIFF
--- a/committeeoversightapp/static/js/grade_sort.js
+++ b/committeeoversightapp/static/js/grade_sort.js
@@ -1,4 +1,4 @@
-// This custom sort function for letter grades relies on the insight from
+// This DataTables sort function for letter grades relies on the insight from
 // https://stackoverflow.com/a/58065608 that ',' is between '+' and '-' in
 // the ASCII table. This sort appends ',' to any grade without a sign and then
 // sorts normally

--- a/committeeoversightapp/static/js/grade_sort.js
+++ b/committeeoversightapp/static/js/grade_sort.js
@@ -1,0 +1,28 @@
+// This custom sort function for letter grades relies on the insight from
+// https://stackoverflow.com/a/58065608 that ',' is between '+' and '-' in
+// the ASCII table. This sort appends ',' to any grade without a sign and then
+// sorts normally
+
+addCommaIfUnsigned = function(grade) {
+    var last_char = grade.substr(-1)
+    if (last_char != "-" && last_char != "+") {
+      grade += ','
+    }
+    return grade
+}
+
+gradeSort = function(a, b) {
+    a = addCommaIfUnsigned(a)
+    b = addCommaIfUnsigned(b)
+    return ((a < b) ? -1 : ((a > b) ? 1 : 0));
+}
+
+jQuery.extend( jQuery.fn.dataTableExt.oSort, {
+    "grade-sort-asc": function ( a, b ) {
+        return gradeSort(a, b);
+    },
+
+    "grade-sort-desc": function ( a, b ) {
+        return gradeSort(a, b) * -1;
+    }
+} );

--- a/committeeoversightapp/templates/committeeoversightapp/landing_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/landing_page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load wagtailcore_tags %}
+{% load static wagtailcore_tags %}
 
 {% block content %}
   <div class="row justify-content-center align-items-center">
@@ -44,6 +44,10 @@
 
   {% include "partials/landing_page_table.html" with committees=senate_committees title="Senate"%}
 
+  {% block extra_js %}
+    <script type="text/javascript" src="{% static 'js/grade_sort.js' %}"></script>
+  {% endblock %}
+
   <script>
     $(document).ready(function() {
       $('.select2-single').select2();
@@ -64,6 +68,7 @@
           "order": [[ 0, "asc" ]],
           "columnDefs": [
             { "orderable": false, "targets": [3, 4, 5] },
+            { type: 'grade-sort', targets: 1 }
           ],
         });
     });

--- a/committeeoversightapp/templates/committeeoversightapp/landing_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/landing_page.html
@@ -68,7 +68,7 @@
           "order": [[ 0, "asc" ]],
           "columnDefs": [
             { "orderable": false, "targets": [3, 4, 5] },
-            { type: 'grade-sort', targets: 1 }
+            { "type": 'grade-sort', "targets": 1 }
           ],
         });
     });

--- a/committeeoversightapp/templates/comparison_page.html
+++ b/committeeoversightapp/templates/comparison_page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load wagtailcore_tags %}
+{% load static wagtailcore_tags %}
 
 {% block content %}
 <div class="row justify-content-center align-items-center">
@@ -16,6 +16,10 @@
 {% block table_content %}
 {% endblock %}
 
+{% block extra_js %}
+  <script type="text/javascript" src="{% static 'js/grade_sort.js' %}"></script>
+{% endblock %}
+
 <script>
   $(document).ready(function () {
       $('.committee-table').DataTable({
@@ -24,6 +28,9 @@
         "searching": false,
         "info": false,
         "order": [[ 0, "asc" ]],
+        "columnDefs": [
+          { "type": 'grade-sort', "targets": [1, 2, 3, 4, 5, 6] }
+        ],
       });
   });
 </script>


### PR DESCRIPTION
## Overview

Closes #100. This PR adds custom sorting to letter grades. For example, the following will be sorted in the order shown: 

`A+, A, A-, B+, B, B-, ...`

## Testing Instructions

* Run the site following instructions in the README
* Go to the [Congress comparison page](http://localhost:8000/compare-committees-over-congresses/) and make sure all grade columns sort as you'd expect
* Make sure the landing page grades sort as you'd expect
