### PR TITLE
Adjust hearings table data displayed

### DIFF
--- a/committeeoversight/settings.py
+++ b/committeeoversight/settings.py
@@ -187,3 +187,14 @@ CHAMBERS = [
     'United States House of Representatives',
     'United States Senate'
 ]
+
+DISPLAY_CATEGORIES = [
+    'Nominations',
+    'Legislative',
+    'Policy',
+    'Agency Conduct',
+    'Private Sector Oversight',
+    'Fact Finding',
+    'Field',
+    'Closed',
+]

--- a/committeeoversightapp/models.py
+++ b/committeeoversightapp/models.py
@@ -521,7 +521,9 @@ class HearingListPage(ResetMixin, Page):
 
     def get_context(self, request):
         context = super(HearingListPage, self).get_context(request)
-        context['categories'] = HearingCategoryType.objects.all()
+        context['categories'] = HearingCategoryType.objects.filter(
+            name__in=settings.DISPLAY_CATEGORIES
+        )
         return context
 
 

--- a/committeeoversightapp/models.py
+++ b/committeeoversightapp/models.py
@@ -9,6 +9,7 @@ from django.db import models
 from django.db.models import Max, Avg
 from django.db.models.fields import TextField, BooleanField
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
 
 from wagtail.core.models import Page
 from wagtail.core.fields import StreamField, RichTextField
@@ -22,6 +23,25 @@ from opencivicdata.core.models import Organization
 from opencivicdata.legislative.models import Event, EventParticipant, \
                                              EventDocument
 
+
+class HearingEvent(Event):
+    class Meta:
+        proxy = True
+
+    @property
+    def category(self):
+        try:
+            return HearingCategory.objects.get(
+                event_id=self.id
+            ).category
+        except ObjectDoesNotExist:
+            return None
+
+    @property
+    def committees(self):
+        return CommitteeOrganization.objects.filter(
+            eventparticipant__event=self.id
+        )
 
 class CommitteeManager(models.Manager):
     def permanent_committees(self):
@@ -45,6 +65,7 @@ class CommitteeManager(models.Manager):
         context['house_committees'] = self.house_committees()
         context['senate_committees'] = self.senate_committees()
         return context
+
 
 class CommitteeOrganization(Organization):
     class Meta:

--- a/committeeoversightapp/static/css/custom.css
+++ b/committeeoversightapp/static/css/custom.css
@@ -268,10 +268,6 @@ input[type='checkbox'] {
   margin-top: 40px;
 }
 
-.hearing-title-col {
-  width: 50%;
-}
-
 #delete-icon {
   color: var(--red-color);
 }

--- a/committeeoversightapp/templates/committeeoversightapp/category_detail_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/category_detail_page.html
@@ -39,7 +39,10 @@
       $('#hearing-table').DataTable({
         "dom": "Bfrtip",
         "order": [[ 0, "desc" ]],
-        "columnDefs": [{ "orderable": false, "targets": [3, 4] }],
+        "columnDefs": [
+          { "searchable": false, "targets": [3], "visible": false },
+          { "orderable": false, "targets": [4, 5] },
+        ],
         "processing": true,
         "serverSide": true,
         "ajax": makeAjaxUrl(categoryID)

--- a/committeeoversightapp/templates/committeeoversightapp/category_detail_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/category_detail_page.html
@@ -41,7 +41,7 @@
         "order": [[ 0, "desc" ]],
         "columnDefs": [
           { "searchable": false, "targets": [3], "visible": false },
-          { "orderable": false, "targets": [4, 5] },
+          { "orderable": false, "targets": [2, 4, 5] },
         ],
         "processing": true,
         "serverSide": true,

--- a/committeeoversightapp/templates/committeeoversightapp/committee_detail_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/committee_detail_page.html
@@ -219,7 +219,7 @@
           "order": [[ 2, "desc" ]],
           "columnDefs": [
               { "searchable": false, "targets": [2], "visible": false },
-              { "orderable": false, "targets": [4, 5] },
+              { "orderable": false, "targets": [3, 4, 5] },
             ],
           "processing": true,
           "serverSide": true,

--- a/committeeoversightapp/templates/committeeoversightapp/committee_detail_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/committee_detail_page.html
@@ -217,7 +217,10 @@
         $('#hearing-table').DataTable({
           "dom": "Bfrtip",
           "order": [[ 2, "desc" ]],
-          "columnDefs": [{ "orderable": false, "targets": [3, 4] }],
+          "columnDefs": [
+              { "searchable": false, "targets": [2], "visible": false },
+              { "orderable": false, "targets": [4, 5] },
+            ],
           "processing": true,
           "serverSide": true,
           "ajax": makeAjaxUrl(committeeID)

--- a/committeeoversightapp/templates/committeeoversightapp/committee_detail_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/committee_detail_page.html
@@ -216,7 +216,7 @@
         }
         $('#hearing-table').DataTable({
           "dom": "Bfrtip",
-          "order": [[ 2, "desc" ]],
+          "order": [[ 0, "desc" ]],
           "columnDefs": [
               { "searchable": false, "targets": [2], "visible": false },
               { "orderable": false, "targets": [3, 4, 5] },

--- a/committeeoversightapp/templates/committeeoversightapp/hearing_list_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/hearing_list_page.html
@@ -39,7 +39,7 @@
       $('#hearing-table').DataTable({
         "dom": "Bfrtip",
         "order": [[ 0, "desc" ]],
-        "columnDefs": [{ "orderable": false, "targets": [3, 4] }],
+        "columnDefs": [{ "orderable": false, "targets": [4, 5] }],
         "processing": true,
         "serverSide": true,
         "ajax": "{% url 'order_list_json' %}"

--- a/committeeoversightapp/templates/committeeoversightapp/hearing_list_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/hearing_list_page.html
@@ -39,10 +39,10 @@
       $('#hearing-table').DataTable({
         "dom": "Bfrtip",
         "order": [[ 0, "desc" ]],
-        "columnDefs": [{ "orderable": false, "targets": [4, 5] }],
+        "columnDefs": [{ "orderable": false, "targets": [2, 3, 4, 5] }],
         "processing": true,
         "serverSide": true,
-        "ajax": "{% url 'order_list_json' %}"
+        "ajax": "{% url 'order_list_json' %}",
       });
   } );
   </script>

--- a/committeeoversightapp/templates/hearing_detail.html
+++ b/committeeoversightapp/templates/hearing_detail.html
@@ -32,10 +32,10 @@
        <tr>
          <td><b>Category</b></td>
          <td>
-          {% if category.url %}
-            <a href="{{ category.url }}">{{category}}</a>
+          {% if hearing.category.url %}
+            <a href="{{ hearing.category.url }}">{{hearing.category}}</a>
           {% else %}
-            {{category}}
+            {{hearing.category}}
           {% endif %}
           </td>
        </tr>

--- a/committeeoversightapp/templates/partials/hearing_table.html
+++ b/committeeoversightapp/templates/partials/hearing_table.html
@@ -2,9 +2,10 @@
   <table class="table table-striped table-borderless {{ table_size }}" id="hearing-table">
      <thead>
        <tr>
-         <th scope="col">Date Updated</th>
-         <th scope="col" class="hearing-title-col">Hearing Title</th>
-         <th scope="col">Hearing Date</th>
+         <th scope="col">Date</th>
+         <th scope="col">Hearing Title</th>
+         <th scope="col">Committee</th>
+         <th scope="col">Category</th>
          {% if request.user.is_superuser %}
            <th scope="col">Edit</th>
            <th scope="col">Delete</th>

--- a/committeeoversightapp/templates/partials/hearing_table.html
+++ b/committeeoversightapp/templates/partials/hearing_table.html
@@ -2,10 +2,10 @@
   <table class="table table-striped table-borderless {{ table_size }}" id="hearing-table">
      <thead>
        <tr>
-         <th scope="col">Date</th>
-         <th scope="col">Hearing Title</th>
-         <th scope="col">Committee</th>
-         <th scope="col">Category</th>
+         <th scope="col" style="min-width:10%;">Date</th>
+         <th scope="col" style="max-width:60%;">Hearing Title</th>
+         <th scope="col" style="min-width:20%;">Committee</th>
+         <th scope="col" style="min-width:10%;">Category</th>
          {% if request.user.is_superuser %}
            <th scope="col">Edit</th>
            <th scope="col">Delete</th>

--- a/committeeoversightapp/templates/partials/hearing_table.html
+++ b/committeeoversightapp/templates/partials/hearing_table.html
@@ -2,7 +2,7 @@
   <table class="table table-striped table-borderless {{ table_size }}" id="hearing-table">
      <thead>
        <tr>
-         <th scope="col" style="min-width:10%;">Date</th>
+         <th scope="col" style="min-width:15%;">Date</th>
          <th scope="col" style="max-width:60%;">Hearing Title</th>
          <th scope="col" style="min-width:20%;">Committee</th>
          <th scope="col" style="min-width:10%;">Category</th>

--- a/committeeoversightapp/templates/partials/top_menu.html
+++ b/committeeoversightapp/templates/partials/top_menu.html
@@ -40,10 +40,6 @@
       <li class="nav-item">
         <small class="mr-4 font-italic">Logged in as <b>{{ request.user.get_username }}</b></small>
       </li>
-     {% else %}
-      <li class="nav-item">
-        <a href="{% url 'login'%}">Login</a>
-      </li>
       {% endif %}
     </ul>
   </div>

--- a/committeeoversightapp/views.py
+++ b/committeeoversightapp/views.py
@@ -7,6 +7,7 @@ from django.views.generic import TemplateView
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.html import escape
+from django.conf import settings
 
 from opencivicdata.legislative.models import Event, EventParticipant, \
                         EventDocument, EventDocumentLink, EventSource
@@ -155,6 +156,7 @@ class EventListJson(BaseDatatableView):
                 category_string
             ]
 
+            # if user is authenticated show edit and delete buttons
             if self.request.user.is_authenticated:
                 row_data += [
                     edit_string.format(
@@ -170,10 +172,13 @@ class EventListJson(BaseDatatableView):
                         ))
                     ),
                 ]
-            else:
+                json_data.append(row_data)
+            # if not authenticated, only include display hearing categories 
+            elif not item.category or item.category.name in settings.DISPLAY_CATEGORIES:
                 row_data += ['', '']
-
-            json_data.append(row_data)
+                json_data.append(row_data)
+            else:
+                pass
 
         return json_data
 

--- a/committeeoversightapp/views.py
+++ b/committeeoversightapp/views.py
@@ -125,15 +125,9 @@ class EventListJson(BaseDatatableView):
             committees = set()
             for committee in item.committees:
                 if committee.is_subcommittee:
-                    committee_string = detail_string.format(
-                        escape(committee.parent_url),
-                        escape(committee.parent)
-                    )
+                    committee_string = str(committee.parent)
                 else:
-                    committee_string = detail_string.format(
-                        escape(committee.url),
-                        escape(committee.name)
-                    )
+                    committee_string = str(committee.name)
                 committees.add(committee_string)
 
             category_string = ''
@@ -173,7 +167,7 @@ class EventListJson(BaseDatatableView):
                     ),
                 ]
                 json_data.append(row_data)
-            # if not authenticated, only include display hearing categories 
+            # if not authenticated, only include display hearing categories
             elif not item.category or item.category.name in settings.DISPLAY_CATEGORIES:
                 row_data += ['', '']
                 json_data.append(row_data)


### PR DESCRIPTION
## Overview

Closes #128.
Closes #131. 

This PR responds to a list of requested changes from Jamie detailed in #128 and #131.

## Testing Instructions

 * Run the site following directions in the README
* Visit http://localhost:8000/hearings/ and make sure you see only the categories listed in `settings.DISPLAY_CATEGORIES` in the list in the top
* Click through a few pages of hearings and make sure you don't see any hearings listed with other categories
* Log in through the footer and make sure that link works
* Go back to http://localhost:8000/hearings/ and make sure you see hearings from all categories
* Visit http://localhost:8000/hearings/, a category detail page, and a committee detail page and make sure the hearings appear newest to oldest by Hearing Date and show the columns  DATE, HEARING TITLE, COMMITTEE, CATEGORY (except for COMMITTEE on committee detail pages and CATEGORY on category detail pages) 