### PR TITLE
Committee link handling

### DIFF
--- a/committeeoversightapp/models.py
+++ b/committeeoversightapp/models.py
@@ -85,8 +85,8 @@ class CommitteeOrganization(Organization):
         return '/committee-' + self.id.split('ocd-organization/').pop()
 
     @property
-    def parent_url(self):
-        return '/committee-' + self.parent.id.split('ocd-organization/').pop()
+    def parent_proxy(self):
+        return CommitteeOrganization.objects.get(id=self.parent.id)
 
     @property
     def short_name(self):
@@ -100,6 +100,47 @@ class CommitteeOrganization(Organization):
             return True
         else:
             return False
+
+    @property
+    def is_permanent(self):
+        if self in CommitteeOrganization.objects.permanent_committees():
+            print("True")
+            return True
+        else:
+            return False
+
+    @property
+    def get_linked_html(self):
+        if self.is_subcommittee:
+            if self.parent_proxy.is_permanent:
+                return '<a href=\"{0}\">{1}</a>, {2}'.format(
+                    self.parent_proxy.url,
+                    self.parent,
+                    self
+                )
+            else:
+                return '{0}, {1}'.format(self.parent, self)
+        else:
+            if self.is_permanent:
+                return '<a href="{0}">{1}</a>'.format(self.url, self)
+            else:
+                return self
+
+    @property
+    def get_linked_html_short(self):
+        if self.is_subcommittee:
+            if self.parent_proxy.is_permanent:
+                return '<a href=\"{0}\">{1}</a>'.format(
+                    self.parent_proxy.url,
+                    self.parent
+                )
+            else:
+                return str(self.parent)
+        else:
+            if self.is_permanent:
+                return '<a href="{0}">{1}</a>'.format(self.url, self)
+            else:
+                return str(self)
 
     @property
     def chair(self):

--- a/committeeoversightapp/models.py
+++ b/committeeoversightapp/models.py
@@ -103,8 +103,7 @@ class CommitteeOrganization(Organization):
 
     @property
     def is_permanent(self):
-        if self in CommitteeOrganization.objects.permanent_committees():
-            print("True")
+        if CommitteeOrganization.objects.permanent_committees().filter(id=self.id).exists():
             return True
         else:
             return False
@@ -116,7 +115,7 @@ class CommitteeOrganization(Organization):
                 return '<a href=\"{0}\">{1}</a>, {2}'.format(
                     self.parent_proxy.url,
                     self.parent,
-                    self
+                    self.name
                 )
             else:
                 return '{0}, {1}'.format(self.parent, self)
@@ -124,7 +123,7 @@ class CommitteeOrganization(Organization):
             if self.is_permanent:
                 return '<a href="{0}">{1}</a>'.format(self.url, self)
             else:
-                return self
+                return self.name
 
     @property
     def get_linked_html_short(self):
@@ -135,12 +134,12 @@ class CommitteeOrganization(Organization):
                     self.parent
                 )
             else:
-                return str(self.parent)
+                return self.parent.name
         else:
             if self.is_permanent:
                 return '<a href="{0}">{1}</a>'.format(self.url, self)
             else:
-                return str(self)
+                return self.name
 
     @property
     def chair(self):

--- a/committeeoversightapp/templates/hearing_detail.html
+++ b/committeeoversightapp/templates/hearing_detail.html
@@ -19,14 +19,11 @@
          <td><b>Committees</b></td>
          <td>
            {% for committee in committees %}
-             {% if committee.is_subcommittee %}
-                <a href="{{ committee.parent_url }}">
-                  {{committee.parent}}</a>, {{committee}}
-              {% else %}
-                <a href="{{ committee.url }}">{{committee}}</a>
-             {% endif %}
+             {% autoescape off %}
+              {{ committee.get_linked_html }}
+             {% endautoescape %}
              <br />
-            {% endfor %}
+           {% endfor %}
          </td>
        </tr>
        <tr>

--- a/committeeoversightapp/views.py
+++ b/committeeoversightapp/views.py
@@ -153,11 +153,7 @@ class EventListJson(BaseDatatableView):
     def get_committees(self, item):
         committees = set()
         for committee in item.committees:
-            if committee.is_subcommittee:
-                committee_string = str(committee.parent)
-            else:
-                committee_string = str(committee.name)
-            committees.add(committee_string)
+            committees.add(committee.get_linked_html_short)
 
         return ', '.join(committees)
 


### PR DESCRIPTION
## Overview

Closes #132. This PR sets up committee links to work for a site with a full set of detail pages for permanent committees, not assuming that any other committee pages will exist. On hearing detail pages and tables of hearings, a committee will now be:

- Listed in form `<PARENT COMMITTEE>`, `<COMMITTEE>` if it's a subcommittee
- Linked to its committee detail page, if permanent


## Testing Instructions

* Run the site following the README
 * View the Browse Hearings page and a committee detail page and make sure they load as expected
* Log in as an admin and pick a random hearing to edit. Add a couple committees and subcommittees, including at least one that's not permanent (see `settings.py` for that list). For example, here's what I did:
<img width="703" alt="Screen Shot 2019-12-16 at 4 17 15 PM" src="https://user-images.githubusercontent.com/1094243/70948024-2cbf5380-2020-11ea-8874-c907b78a5eb8.png">
* Check various views for this hearing and make sure it shows up correctly