### PR TITLE
Design review feedback: the quicker changes

### DIFF
--- a/committeeoversightapp/models.py
+++ b/committeeoversightapp/models.py
@@ -155,13 +155,13 @@ class CommitteeOrganization(Organization):
         return round(self.ratings_by_congress_desc \
             .aggregate(
                 Avg(hearing_type)
-            )[hearing_type + '__avg'], 2)
+            )[hearing_type + '__avg'], 1)
 
     def get_max_rating(self, hearing_type):
         return round(self.ratings_by_congress_desc \
             .aggregate(
                 Max(hearing_type)
-            )[hearing_type + '__max'], 2)
+            )[hearing_type + '__max'], 1)
 
     def __str__(self):
         return self.name
@@ -189,7 +189,7 @@ class Congress(models.Model):
     def percent_passed(self):
         days_in_session = 668
         days_passed = (date.today() - self.start_date).days
-        percent_passed = round(days_passed / days_in_session * 100, 2)
+        percent_passed = int(round(days_passed / days_in_session * 100))
 
         if percent_passed <= 100:
             return percent_passed
@@ -215,10 +215,10 @@ class CommitteeRating(models.Model):
                 / self.committee.max_chp_points * 100
 
             if not self.congress.is_current:
-                return round(current_score, 2)
+                return int(round(current_score))
             else:
-                return round(current_score / self.congress.percent_passed \
-                    * 100, 2)
+                return int(round(current_score / self.congress.percent_passed \
+                    * 100))
 
         except ZeroDivisionError:
             print("Divide by zero error on " + self.committee.name)
@@ -303,15 +303,15 @@ class CommitteeRating(models.Model):
 
     def get_percent_max(self, hearing_type):
         try:
-            return round(getattr(self, hearing_type) \
-                / getattr(self.committee, hearing_type + '_max') * 100, 2)
+            return int(round(getattr(self, hearing_type) \
+                / getattr(self.committee, hearing_type + '_max') * 100))
         except ZeroDivisionError:
             return 0
 
     def get_percent_avg(self, hearing_type):
         try:
-            return round(getattr(self, hearing_type) \
-                / getattr(self.committee, hearing_type + '_avg') * 100, 2)
+            return int(round(getattr(self, hearing_type) \
+                / getattr(self.committee, hearing_type + '_avg') * 100))
         except ZeroDivisionError:
             return 0
 

--- a/committeeoversightapp/models.py
+++ b/committeeoversightapp/models.py
@@ -189,7 +189,7 @@ class Congress(models.Model):
     def percent_passed(self):
         days_in_session = 668
         days_passed = (date.today() - self.start_date).days
-        percent_passed = int(round(days_passed / days_in_session * 100))
+        percent_passed = round(days_passed / days_in_session * 100)
 
         if percent_passed <= 100:
             return percent_passed
@@ -215,10 +215,10 @@ class CommitteeRating(models.Model):
                 / self.committee.max_chp_points * 100
 
             if not self.congress.is_current:
-                return int(round(current_score))
+                return round(current_score)
             else:
-                return int(round(current_score / self.congress.percent_passed \
-                    * 100))
+                return round(current_score / self.congress.percent_passed \
+                    * 100)
 
         except ZeroDivisionError:
             print("Divide by zero error on " + self.committee.name)
@@ -303,15 +303,15 @@ class CommitteeRating(models.Model):
 
     def get_percent_max(self, hearing_type):
         try:
-            return int(round(getattr(self, hearing_type) \
-                / getattr(self.committee, hearing_type + '_max') * 100))
+            return round(getattr(self, hearing_type) \
+                / getattr(self.committee, hearing_type + '_max') * 100)
         except ZeroDivisionError:
             return 0
 
     def get_percent_avg(self, hearing_type):
         try:
-            return int(round(getattr(self, hearing_type) \
-                / getattr(self.committee, hearing_type + '_avg') * 100))
+            return round(getattr(self, hearing_type) \
+                / getattr(self.committee, hearing_type + '_avg') * 100)
         except ZeroDivisionError:
             return 0
 

--- a/committeeoversightapp/static/css/custom.css
+++ b/committeeoversightapp/static/css/custom.css
@@ -293,6 +293,12 @@ input[type='checkbox'] {
   color: var(--dark-blue-color);
 }
 
+:target {
+  padding-top: 40px;
+  margin-top: -40px;
+  display: inline-block;
+}
+
 .navbar {
   background-color: var(--dark-blue-color);
   padding: .5rem 3rem 0rem 1.5rem;

--- a/committeeoversightapp/templates/committeeoversightapp/category_detail_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/category_detail_page.html
@@ -45,7 +45,10 @@
         ],
         "processing": true,
         "serverSide": true,
-        "ajax": makeAjaxUrl(categoryID)
+        "ajax": makeAjaxUrl(categoryID),
+        "language": {
+          "infoFiltered": ""
+        },
       });
   });
   </script>

--- a/committeeoversightapp/templates/committeeoversightapp/committee_detail_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/committee_detail_page.html
@@ -223,7 +223,10 @@
             ],
           "processing": true,
           "serverSide": true,
-          "ajax": makeAjaxUrl(committeeID)
+          "ajax": makeAjaxUrl(committeeID),
+          "language": {
+            "infoFiltered": ""
+          },
         });
     });
   </script>

--- a/committeeoversightapp/templates/committeeoversightapp/hearing_list_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/hearing_list_page.html
@@ -43,6 +43,9 @@
         "processing": true,
         "serverSide": true,
         "ajax": "{% url 'order_list_json' %}",
+        "language": {
+          "infoFiltered": ""
+        },
       });
   } );
   </script>

--- a/committeeoversightapp/templates/committeeoversightapp/landing_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/landing_page.html
@@ -33,16 +33,16 @@
       </div>
       <div class="mx-3">
         <a href="{% slugurl 'compare-committees-over-congresses' %}">
-          Compare committees over Congresses
+          Compare ratings over Congresses
           <i class="fas fa-sm fa-angle-double-right"></i>
         </a>
       </div>
     </div>
   </div>
 
-  {% include "partials/landing_page_table.html" with committees=house_committees title="House of Representatives"%}
+  {% include "partials/landing_page_table.html" with committees=house_committees title="House of Representatives" id="house"%}
 
-  {% include "partials/landing_page_table.html" with committees=senate_committees title="Senate"%}
+  {% include "partials/landing_page_table.html" with committees=senate_committees title="Senate" id="senate"%}
 
   {% block extra_js %}
     <script type="text/javascript" src="{% static 'js/grade_sort.js' %}"></script>

--- a/committeeoversightapp/templates/hearing_detail.html
+++ b/committeeoversightapp/templates/hearing_detail.html
@@ -4,7 +4,7 @@
 <div class="row justify-content-center">
   <div class="col col-lg-11">
   <div class="hearing-form card">
-    <h2 class="text-center">{{hearing.name|title }}</h2>
+    <h2 class="text-center">{{hearing.name}}</h2>
     <br />
 
     <table class="table table-striped table-bordered" id="hearing-table">

--- a/committeeoversightapp/templates/partials/compare_current_committees_table.html
+++ b/committeeoversightapp/templates/partials/compare_current_committees_table.html
@@ -37,19 +37,27 @@
       <tbody>
           {% for committee in committees %}
           <tr>
-            <td class="list-item text-right pr-3 border-right"><a href="{{committee.url}}">{{committee.short_name}}</a></td>
+            <td class="list-item text-right pr-3 border-right">
+              <a href="{{committee.url}}">{{committee.short_name}}</a>
+            </td>
 
             <td>{{committee.latest_rating.investigative_oversight_hearings}}</td>
             <td>{{committee.investigative_oversight_hearings_avg}}</td>
-            <td class="border-right pr-3">{{committee.latest_rating.investigative_oversight_percent_avg}}%</td>
+            <td class="border-right pr-3 font-weight-bold">
+              {{committee.latest_rating.investigative_oversight_percent_avg}}%
+            </td>
 
             <td>{{committee.latest_rating.policy_legislative_hearings}}</td>
             <td>{{committee.policy_legislative_hearings_avg}}</td>
-            <td class="border-right pr-3">{{committee.latest_rating.policy_legislative_percent_avg}}%</td>
+            <td class="border-right pr-3 font-weight-bold">
+              {{committee.latest_rating.policy_legislative_percent_avg}}%
+            </td>
 
             <td>{{committee.latest_rating.total_hearings}}</td>
             <td>{{committee.total_hearings_avg}}</td>
-            <td class="pr-3">{{committee.latest_rating.total_percent_avg}}%</td>
+            <td class="pr-3 font-weight-bold">
+              {{committee.latest_rating.total_percent_avg}}%
+            </td>
           </tr>
           {% endfor %}
       </tbody>

--- a/committeeoversightapp/templates/partials/landing_page_table.html
+++ b/committeeoversightapp/templates/partials/landing_page_table.html
@@ -1,3 +1,5 @@
+<a class="anchor" id="{{id}}"></a>
+
 <div class="card mt-5 col-12 col-lg-10 mx-auto card-shadow">
   <h4 class="text-center mt-4">{{title}}</h4>
   <div class="card-body">

--- a/committeeoversightapp/templates/partials/top_menu.html
+++ b/committeeoversightapp/templates/partials/top_menu.html
@@ -10,9 +10,6 @@
   </a>
   <div class="collapse navbar-collapse" id="navbarNav">
     <ul class="navbar-nav ml-auto">
-      <li class="nav-item">
-        <a href="/">Home</a>
-      </li>
       {% for menuitem in menuitems %}
       <li class="nav-item {% if menuitem.show_dropdown %}dropdown{% endif %}{% if calling_page.url == menuitem.url %} active{% endif %}">
           {% if menuitem.show_dropdown %}

--- a/committeeoversightapp/views.py
+++ b/committeeoversightapp/views.py
@@ -147,7 +147,7 @@ class EventListJson(BaseDatatableView):
                 'detail-event',
                 kwargs={'pk':item.pk}
             )),
-            escape(item.name.title())
+            escape(item.name)
         )
 
     def get_committees(self, item):


### PR DESCRIPTION
## Overview

Connects #135. The rest of the items in that issue can be iceboxed and picked up if there's time. This PR completes these items from #135:

**Landing page**
- Make sure the arrows on the compare links aren't pushed to a new line
- Add anchors to House and Senate cards

**Comparison pages**
- Round percentages to whole numbers and everything else to 1 decimal across site
- Format percentages differently; bold or different color

**Detail pages**
 - Cut bottom DataTables text. "Filtered from ____ total hearings"
 - Stop converting hearing titles to title case. It leads to some wonky problems! 

## Testing Instructions

* Run the site according to the README instructions
* Check that each of these changes works as expected 