### PR TITLE
Upgrade Wagtail & switch db backups to staging

### DIFF
--- a/committeeoversight/settings.py
+++ b/committeeoversight/settings.py
@@ -155,6 +155,8 @@ LOGIN_REDIRECT_URL = '/'
 
 WAGTAIL_SITE_NAME = 'Committee Oversight'
 
+WAGTAIL_MODERATION_ENABLED = False
+
 CURRENT_PERMANENT_COMMITTEES = [
     'House Committee on Agriculture',
     'House Committee on Appropriations',

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ django-crispy-forms==1.7.2
 requests>=2.20.0
 urllib3==1.24.2
 django-datatables-view==1.17.0
-wagtail==2.6.2
+wagtail==2.7
 
 jinja2==2.10.1
 gunicorn==19.9.0

--- a/scripts/after_install.sh
+++ b/scripts/after_install.sh
@@ -56,7 +56,7 @@ fi
 $venv_dir/bin/python $project_dir/scripts/render_configs.py $DEPLOYMENT_ID $DEPLOYMENT_GROUP_NAME
 
 # Move crontask to correct place, and assign correct ownership and permissions.
-if [ "$DEPLOYMENT_GROUP_NAME" == "production" ]; then
+if [ "$DEPLOYMENT_GROUP_NAME" == "staging" ]; then
   mv $project_dir/scripts/committee-oversight-crontasks /etc/cron.d/committee-oversight-crontasks
   chown root.root /etc/cron.d/committee-oversight-crontasks
   chmod 644 /etc/cron.d/committee-oversight-crontasks


### PR DESCRIPTION
## Overview

Closes #133. This PR upgrades Wagtail to 2.7 and makes use of its new `WAGTAIL_MODERATION_ENABLED` setting, which would take some additional setup to get running.

Wagtail 2.7 release notes here: https://docs.wagtail.io/en/v2.7/releases/2.7.html

It also switches the DB backup cronjob to run only on staging, which should be switched back once we move Lugar over to inputting data on the production site.
