### PR TITLE
Hide ratings on committee detail pages

### DIFF
--- a/committeeoversightapp/templates/committeeoversightapp/committee_detail_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/committee_detail_page.html
@@ -15,6 +15,7 @@
   </div>
 
   <div class="row justify-content-center align-items-center">
+    {% if not page.hide_rating %}
     <div class="col-6 col-md-4 col-lg-3 col-xl-3 my-3 pr-4 text-right border-right">
       <h3 class="rating-large {{latest_rating.css_class}}">
         {{latest_rating}}
@@ -24,6 +25,7 @@
         <small><i>Last updated: {% now "jS F Y H:i" %}</i></small>
       </p>
     </div>
+    {% endif %}
 
     <div class="col-6 col-md-5 col-lg-4 col-xl-3 my-3 pl-4 text-left">
       <p class="font-weight-light my-2">

--- a/committeeoversightapp/templates/partials/rating_table.html
+++ b/committeeoversightapp/templates/partials/rating_table.html
@@ -7,18 +7,26 @@
                   Number of Hearings
                   <hr class="mb-0" />
               </td>
-              <td colspan="2" class="font-weight-bold">
-                  Committee Hearing Performance
-                  <hr class="mb-0" />
-              </td>
+
+              {% if not page.hide_rating %}
+                <td colspan="2" class="font-weight-bold">
+                    Committee Hearing Performance
+                    <hr class="mb-0" />
+                </td>
+              {% endif %}
+
           </tr>
           <tr>
               <td></td>
               <td>Investigative/Oversight</td>
               <td>Policy/Legislative</td>
               <td>Total Hearings</td>
-              <td>Score</td>
-              <td>Grade</td>
+
+              {% if not page.hide_rating %}
+                <td>Score</td>
+                <td>Grade</td>
+              {% endif %}
+
           </tr>
       </thead>
       <tbody>
@@ -28,8 +36,12 @@
               <td>{{committeerating.investigative_oversight_hearings}}</td>
               <td>{{committeerating.policy_legislative_hearings}}</td>
               <td>{{committeerating.total_hearings}}</td>
-              <td>{{committeerating.chp_score}}%</td>
-              <td class="{{committeerating.css_class}} font-weight-bold lead">{{committeerating}}</td>
+
+              {% if not page.hide_rating %}
+                <td>{{committeerating.chp_score}}%</td>
+                <td class="{{committeerating.css_class}} font-weight-bold lead">{{committeerating}}</td>
+              {% endif %}
+
           </tr>
           {% endfor %}
           <tr>
@@ -37,8 +49,11 @@
               <td class="font-weight-bold">{{page.committee.investigative_oversight_hearings_avg}}</td>
               <td class="font-weight-bold">{{page.committee.policy_legislative_hearings_avg}}</td>
               <td class="font-weight-bold">{{page.committee.total_hearings_avg}}</td>
-              <td></td>
-              <td></td>
+
+              {% if not page.hide_rating %}
+                <td></td>
+                <td></td>
+              {% endif %}
           </tr>
       </tbody>
   </table>


### PR DESCRIPTION
## Overview

Closes #106, following Jamie's instructions:

> For committee pages without ratings, we should exclude the letter grade up top and then the 2 columns under “Committee Hearing Performance” in the committee history section. All other things should stay

