### PR TITLE
Fix duplicate hearings displayed on committee detail pages

### DIFF
--- a/committeeoversightapp/views.py
+++ b/committeeoversightapp/views.py
@@ -111,7 +111,7 @@ class EventListJson(BaseDatatableView):
             qs = qs.filter(
                 Q(participants__organization_id=id) |
                 Q(participants__organization__parent_id=id)
-            )
+            ).distinct()
 
         # based on search example at
         # https://pypi.org/project/django-datatables-view/


### PR DESCRIPTION
## Overview

Closes #144. 

Jamie noted a problem where hearings with multiple committees were listed multiple times on the site. After some investigation, I pinned down that the duplicate hearings displayed had the same id, and were not actually duplicates in the data. This problem was only occurring on the Committee detail pages (ie, not the browse all hearings page or the Category detail pages) and stemmed from this query in `committeeoversightapp.views.EventListJson` producing duplicate entries of the same hearing record:

```python
qs = qs.filter(
	Q(participants__organization_id=id) |
	Q(participants__organization__parent_id=id)
)
```

This StackOverflow question describes the problem: https://stackoverflow.com/questions/34468505/why-is-django-queryset-with-q-expression-returning-duplicate-values

Adding `distinct()` to the end of the above query solves the problem, which is what StackOverflow recommends.

It seems this has been reported before as a bug in Django and closed with the note that `distinct()` is the correct path forward: https://code.djangoproject.com/ticket/28292?cversion=0&cnum_hist=2

This solution doesn't feel very satisfying but Django doesn't seem to offer a better option. Curious to hear your thoughts @hancush !

## Testing Instructions

 * Run the site according the the README
* Create a committee detail page for the House Committee on Education and the Workforce (documentation [here](https://docs.google.com/document/d/1RmmLKMUw2OwjYNAR3Lqh_KfFVYcHDxo9gAJot6tSvKw/edit#heading=h.aq1ctxfo0d9j))
* Visit http://localhost:8000/committee-1bb49009-b5d8-42c5-9524-019e80b677da/ 
* Scroll to the bottom hearings table and search for "Paycheck Fairness Act (H.R. 7): Equal Pay for Equal Work"
* Confirm you see just one result