### PR TITLE
Use original transcript links, not webarchive

### DIFF
--- a/committeeoversightapp/management/commands/load_committeeratings.py
+++ b/committeeoversightapp/management/commands/load_committeeratings.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
         # Policy/Legislative = Policy Hearings + Legislative Hearings
         policy_legislative_hearings=self.count_by_category(
             committee_hearings,
-            ['Legislative', 'Policy']
+            ['Legislative', 'Policy', 'Closed']
         )
 
         # Total = Agency Conduct + Private Sector + Policy + Legislative

--- a/committeeoversightapp/management/commands/load_committeeratings.py
+++ b/committeeoversightapp/management/commands/load_committeeratings.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
         # Policy/Legislative = Policy Hearings + Legislative Hearings
         policy_legislative_hearings=self.count_by_category(
             committee_hearings,
-            ['Legislative', 'Policy', 'Closed']
+            ['Legislative', 'Policy']
         )
 
         # Total = Agency Conduct + Private Sector + Policy + Legislative

--- a/committeeoversightapp/templates/hearing_detail.html
+++ b/committeeoversightapp/templates/hearing_detail.html
@@ -38,9 +38,7 @@
        </tr>
        <tr>
            <td><b>Transcript URL</b></td>
-           {% if transcript_archived and transcript%}
-              <td><a href={{transcript_archived}} target="_blank">{{transcript}}</a></td>
-           {% elif transcript %}
+           {% if transcript %}
               <td><a href={{transcript}} target="_blank">{{transcript}}</a></td>
            {% else %}
               <td></td>


### PR DESCRIPTION
## Overview

Closes #154. Upon investigation, it looks like senate.gov is blocking sites archived by webarchive. I've switched the committee detail pages to show the original transcript links as they're input. The archived links will still be created and stored in the database, if we want to go back and use those later. 

<img width="1388" alt="Screen Shot 2020-02-12 at 1 12 35 PM" src="https://user-images.githubusercontent.com/1094243/74368597-99916880-4d99-11ea-8adc-4391ae630a0b.png">

