### PR TITLE
Add committee ratings crontask

### DIFF
--- a/scripts/after_install.sh
+++ b/scripts/after_install.sh
@@ -57,7 +57,6 @@ $venv_dir/bin/python $project_dir/scripts/render_configs.py $DEPLOYMENT_ID $DEPL
 
 # Move crontask to correct place, and assign correct ownership and permissions.
 if [ "$DEPLOYMENT_GROUP_NAME" == "staging" ]; then
-  mv $project_dir/scripts/committee-oversight-crontasks /etc/cron.d/committee-oversight-crontasks
   chown root.root /etc/cron.d/committee-oversight-crontasks
   chmod 644 /etc/cron.d/committee-oversight-crontasks
 fi

--- a/scripts/committee-oversight-crontasks
+++ b/scripts/committee-oversight-crontasks
@@ -1,4 +1,7 @@
 # /etc/cron.d/committee-oversight-crontasks
 
-# Back up the hearings database at 4 PM GMT every day.
-0 16 * * * datamade (pg_dump -Fc -U postgres -d hearings | /usr/bin/aws s3 cp - s3://datamade-postgresql-backups/hearings/$(date -d "today" +"\%Y\%m\%d\%H\%M").dump) && echo "staging backup $(date -d "today" +"\%Y\%m\%d\%H\%M").dump complete" >> /tmp/committee-oversight-crontasks.log 2>&1
+# Back up the hearings database at 4 AM GMT (11pm EST) every day.
+0 4 * * * datamade (pg_dump -Fc -U postgres -d hearings | /usr/bin/aws s3 cp - s3://datamade-postgresql-backups/hearings/$(date -d "today" +"\%Y\%m\%d\%H\%M").dump) && echo "staging backup $(date -d "today" +"\%Y\%m\%d\%H\%M").dump complete" >> /tmp/committee-oversight-crontasks.log 2>&1
+
+# Update the Committee Ratings table every hour.
+0 * * * * datamade cd /home/datamade/committee-oversight-{{ deployment_id }} && /home/datamade/.virtualenvs/committee-oversight-{{ deployment_id }}/bin/python manage.py load_committeeratings >> /tmp/committee-oversight-crontasks.log 2>&1

--- a/scripts/render_configs.py
+++ b/scripts/render_configs.py
@@ -19,9 +19,13 @@ if __name__ == "__main__":
   nginx_template_path = '/home/datamade/committee-oversight-{0}/configs/committee-oversight-{1}.conf.nginx'.format(
     deployment_id, deployment_group)
   nginx_outpath = '/etc/nginx/conf.d/committee-oversight.conf'
+
   supervisor_template_path = '/home/datamade/committee-oversight-{0}/configs/committee-oversight-{1}.conf.supervisor'.format(
     deployment_id, deployment_group)
   supervisor_outpath = '/etc/supervisor/conf.d/committee-oversight.conf'
+
+  crontask_template_path = '/home/datamade/committee-oversight-{0}/scripts/committee-oversight-crontasks'.format(deployment_id)
+  crontask_outpath = '/etc/cron.d/committee-oversight-crontasks'
 
   with open(nginx_template_path) as f:
     nginx_conf = Template(f.read())
@@ -36,8 +40,16 @@ if __name__ == "__main__":
     supervisor_rendered = supervisor_conf.render(
       {'deployment_id': deployment_id})
 
+  with open(crontask_template_path) as f:
+    crontask_conf = Template(f.read())
+    contask_rendered = crontask_conf.render(
+      {'deployment_id': deployment_id})
+
   with open(nginx_outpath, 'w') as out:
     out.write(nginx_rendered)
 
   with open(supervisor_outpath, 'w') as out:
     out.write(supervisor_rendered)
+
+  with open(crontask_outpath, 'w') as out:
+    out.write(contask_rendered)

--- a/scripts/render_configs.py
+++ b/scripts/render_configs.py
@@ -1,33 +1,33 @@
 if __name__ == "__main__":
+    
+    import sys
 
-  import sys
+    from os.path import abspath, dirname, join
 
-  from os.path import abspath, dirname, join
+    path = abspath(join(dirname(__file__), '..'))
+    sys.path.insert(1, path)
 
-  path = abspath(join(dirname(__file__), '..'))
-  sys.path.insert(1, path)
+    from jinja2 import Template
 
-  from jinja2 import Template
+    deployment_id, deployment_group = sys.argv[1:]
 
-  deployment_id, deployment_group = sys.argv[1:]
-
-  domains = {
+    domains = {
     'staging': 'committeeoversight.datamade.us',
     'production': 'committeeoversight-production.datamade.us',
-  }
+    }
 
-  nginx_template_path = '/home/datamade/committee-oversight-{0}/configs/committee-oversight-{1}.conf.nginx'.format(
+    nginx_template_path = '/home/datamade/committee-oversight-{0}/configs/committee-oversight-{1}.conf.nginx'.format(
     deployment_id, deployment_group)
-  nginx_outpath = '/etc/nginx/conf.d/committee-oversight.conf'
+    nginx_outpath = '/etc/nginx/conf.d/committee-oversight.conf'
 
-  supervisor_template_path = '/home/datamade/committee-oversight-{0}/configs/committee-oversight-{1}.conf.supervisor'.format(
+    supervisor_template_path = '/home/datamade/committee-oversight-{0}/configs/committee-oversight-{1}.conf.supervisor'.format(
     deployment_id, deployment_group)
-  supervisor_outpath = '/etc/supervisor/conf.d/committee-oversight.conf'
+    supervisor_outpath = '/etc/supervisor/conf.d/committee-oversight.conf'
 
-  crontask_template_path = '/home/datamade/committee-oversight-{0}/scripts/committee-oversight-crontasks'.format(deployment_id)
-  crontask_outpath = '/etc/cron.d/committee-oversight-crontasks'
+    crontask_template_path = '/home/datamade/committee-oversight-{0}/scripts/committee-oversight-crontasks'.format(deployment_id)
+    crontask_outpath = '/etc/cron.d/committee-oversight-crontasks'
 
-  with open(nginx_template_path) as f:
+    with open(nginx_template_path) as f:
     nginx_conf = Template(f.read())
     context = {
       'deployment_id': deployment_id,
@@ -35,21 +35,21 @@ if __name__ == "__main__":
     }
     nginx_rendered = nginx_conf.render(context)
 
-  with open(supervisor_template_path) as f:
+    with open(supervisor_template_path) as f:
     supervisor_conf = Template(f.read())
     supervisor_rendered = supervisor_conf.render(
       {'deployment_id': deployment_id})
 
-  with open(crontask_template_path) as f:
+    with open(crontask_template_path) as f:
     crontask_conf = Template(f.read())
     contask_rendered = crontask_conf.render(
       {'deployment_id': deployment_id})
 
-  with open(nginx_outpath, 'w') as out:
+    with open(nginx_outpath, 'w') as out:
     out.write(nginx_rendered)
 
-  with open(supervisor_outpath, 'w') as out:
+    with open(supervisor_outpath, 'w') as out:
     out.write(supervisor_rendered)
 
-  with open(crontask_outpath, 'w') as out:
+    with open(crontask_outpath, 'w') as out:
     out.write(contask_rendered)


### PR DESCRIPTION
## Overview

Closes #160. This PR sets up a crontask to run the `load_committeeratings` management command every hour to update grade calculations. 

Currently this will run only for the staging site. That will be switched to production in #141 

@hancush I ssh-ed into the staging site and ran this command with the current deployment ID to make sure it works. You could do the same to test, or we could deploy this and monitor it there.