### PR TITLE
Fix comparison page sorting

### DIFF
--- a/committeeoversightapp/templates/committeeoversightapp/compare_committees_over_congresses_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/compare_committees_over_congresses_page.html
@@ -11,4 +11,18 @@
     </div>
   </div>
 
+  <script>
+    $(document).ready(function () {
+        $('.committee-table').DataTable({
+          "dom": "Bfrtip",
+          "paging": false,
+          "searching": false,
+          "info": false,
+          "order": [[ 0, "asc" ]],
+          "columnDefs": [
+            { "type": 'grade-sort', "targets": [1, 2, 3, 4, 5, 6] }
+          ],
+        });
+    });
+  </script>
 {% endblock %}

--- a/committeeoversightapp/templates/committeeoversightapp/compare_current_committees_page.html
+++ b/committeeoversightapp/templates/committeeoversightapp/compare_current_committees_page.html
@@ -4,4 +4,16 @@
 {% block table_content %}
   {% include "partials/compare_current_committees_table.html" with committees=house_committees title="House of Representatives"%}
   {% include "partials/compare_current_committees_table.html" with committees=senate_committees title="Senate"%}
+
+  <script>
+    $(document).ready(function () {
+        $('.committee-table').DataTable({
+          "dom": "Bfrtip",
+          "paging": false,
+          "searching": false,
+          "info": false,
+          "order": [[ 0, "asc" ]]
+        });
+    });
+  </script>
 {% endblock %}

--- a/committeeoversightapp/templates/comparison_page.html
+++ b/committeeoversightapp/templates/comparison_page.html
@@ -20,19 +20,4 @@
   <script type="text/javascript" src="{% static 'js/grade_sort.js' %}"></script>
 {% endblock %}
 
-<script>
-  $(document).ready(function () {
-      $('.committee-table').DataTable({
-        "dom": "Bfrtip",
-        "paging": false,
-        "searching": false,
-        "info": false,
-        "order": [[ 0, "asc" ]],
-        "columnDefs": [
-          { "type": 'grade-sort', "targets": [1, 2, 3, 4, 5, 6] }
-        ],
-      });
-  });
-</script>
-
 {% endblock %}


### PR DESCRIPTION
## Overview

Closes #189. This PR fixes the percentage sort on the committee comparison page. It was previously being overridden by the custom `grade_sort` javascript. 
