### PR TITLE
Adjust percent_passed calculation

### DIFF
--- a/committeeoversightapp/models.py
+++ b/committeeoversightapp/models.py
@@ -316,6 +316,10 @@ class Congress(models.Model):
 
     @property
     def percent_passed(self):
+        # returns the % of days passed of the current Congress compared
+        # to an average Congress length. This does not take atypical values
+        # for self.inactive_days into account, as inactive_days do not
+        # typically indicate a change in Congress's start and end dates
         days_passed = (date.today() - self.start_date).days
 
         percent_passed = round(

--- a/committeeoversightapp/models.py
+++ b/committeeoversightapp/models.py
@@ -316,10 +316,12 @@ class Congress(models.Model):
 
     @property
     def percent_passed(self):
-        # returns the % of days passed of the current Congress compared
-        # to an average Congress length. This does not take atypical values
-        # for self.inactive_days into account, as inactive_days do not
-        # typically indicate a change in Congress's start and end dates
+        '''
+        Returns the % of days passed of the current Congress compared
+        to an average Congress length. This does not take atypical values
+        for self.inactive_days into account, as inactive_days do not
+        typically indicate a change in Congress's start and end dates
+        '''
         days_passed = (date.today() - self.start_date).days
 
         percent_passed = round(

--- a/committeeoversightapp/models.py
+++ b/committeeoversightapp/models.py
@@ -319,8 +319,10 @@ class Congress(models.Model):
         days_passed = (date.today() - self.start_date).days
 
         percent_passed = round(
-            days_passed / (self.length_in_days - self.inactive_days)  * 100
-            )
+            days_passed / (
+                self.length_in_days - settings.DEFAULT_CONGRESS_INACTIVE_DAYS
+            ) * 100
+        )
 
         return cap_100(percent_passed)
 


### PR DESCRIPTION
## Overview

Closes #188. This PR responds to an issue Jamie noted where a current Congress's CHP score wasn't changing when she updated the `inactive_days`. 

Looking into this, I found a circle in the logic I implemented in #176. By both adding a normalizer to the `chp_score` property of `CommitteeRatings` and `percent_passed`, the two effectively cancel each other out. Thinking this through, I've landed on the side of thinking that `percent_passed` doesn't actually need to be normalized—though the current Congress has more days inactive, we're not further along in it than usual. In this PR I've taken the consideration of unusual inactive days out from the way `percent_passed` is calculated, which fixes the problem Jamie noted. Now, when `inactive_days` is modified for a current Congress, the `chp_score` is affected as we'd expect.

It would be helpful to have you check my thinking here, @hancush, before pushing these changes. Let me know if you'd prefer to talk this through on a call, as it's a little convoluted.
