### PR TITLE
Add sitemaps and analytics

### DIFF
--- a/committeeoversight/settings.py
+++ b/committeeoversight/settings.py
@@ -48,6 +48,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sitemaps',
     'opencivicdata',
     'opencivicdata.core',
     'opencivicdata.legislative',

--- a/committeeoversight/urls.py
+++ b/committeeoversight/urls.py
@@ -17,20 +17,38 @@ from django.conf import settings
 from django.urls import include, path, re_path
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.contrib.sitemaps import GenericSitemap
 
+from wagtail.contrib.sitemaps import views, Sitemap
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
 from wagtail.core import urls as wagtail_urls
 
 from committeeoversightapp.views import pong
+from committeeoversightapp.models import HearingEvent
+
+
+sitemaps = {
+    'hearings': GenericSitemap(
+        {
+            'queryset': HearingEvent.objects.all(),
+            'date_field': 'updated_at'
+        },
+        priority=0.9
+    ),
+    'wagtail': Sitemap
+}
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('pong/', pong,),
     path('', include('committeeoversightapp.urls')),
+    path('sitemap.xml', views.index, {'sitemaps': sitemaps}),
+    path('sitemap-<section>.xml', views.sitemap, {'sitemaps': sitemaps},
+         name='django.contrib.sitemaps.views.sitemap'),
     re_path(r'^cms/', include(wagtailadmin_urls)),
     re_path(r'^documents/', include(wagtaildocs_urls)),
-    re_path(r'', include(wagtail_urls)),
+    re_path(r'', include(wagtail_urls))
 ]
 
 if settings.DEBUG:

--- a/committeeoversight/urls.py
+++ b/committeeoversight/urls.py
@@ -31,7 +31,7 @@ from committeeoversightapp.models import HearingEvent
 sitemaps = {
     'hearings': GenericSitemap(
         {
-            'queryset': HearingEvent.objects.all(),
+            'queryset': HearingEvent.objects.all().order_by('id'),
             'date_field': 'updated_at'
         },
         priority=0.9

--- a/committeeoversightapp/models.py
+++ b/committeeoversightapp/models.py
@@ -29,6 +29,9 @@ class HearingEvent(Event):
     class Meta:
         proxy = True
 
+    def get_absolute_url(self):
+        return '/hearing/view/{}/'.format(self.id)
+
     @property
     def category(self):
         try:

--- a/committeeoversightapp/templates/base.html
+++ b/committeeoversightapp/templates/base.html
@@ -30,6 +30,16 @@
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
     <link href="https://fonts.googleapis.com/css?family=Roboto+Slab:300,400|Roboto:300,400,400i,500,700,700i&display=swap" rel="stylesheet">
 
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-166304411-1"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-166304411-1');
+    </script>
+
     <title>{{page.title}}</title>
   </head>
 


### PR DESCRIPTION
## Overview

Connects #149. I found that `wget`'s spider mode missed the individual hearing pages, so I've created a sitemap for this app. It comes in two parts: 
1. Wagtail's default generated sitemap, created using [their documentation](https://docs.wagtail.io/en/stable/reference/contrib/sitemaps.html)
2. A separate sitemap for the hearings, created using [GenericSitemap](https://docs.djangoproject.com/en/3.0/ref/contrib/sitemaps/#shortcuts)

One snag here is that the sitemap generated for #2 (http://localhost:8000/sitemap-hearings.xml) is just a blob of links, not the structured XML I'd expect to see. I tried creating this sitemap using `django.contrib.sitemaps.Sitemap` but got the same results. I'm wondering if this is something Django does to keep large sitemaps to a reasonable file size, but wasn't able to find documentation. Does this look familiar, @hancush?

I've also added a Google Analytics tag in this PR, to facilitate [pinging Google
](https://docs.djangoproject.com/en/3.0/ref/contrib/sitemaps/#pinging-google) to reindex the site regularly. That ping could be added to a crontask or elsewhere in a separate PR.

## Testing Instructions

 * Run the site locally following README instructions
* Visit http://localhost:8000/sitemap.xml and confirm you see XML with references to the two sitemaps described above
* Visit each and confirm that they contain the right content
